### PR TITLE
chore: make project Commitizen-friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .externalNativeBuild
 /release
 /tmp
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # legado
+
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+
 ## 阅读3.0
 书源规则 https://celeter.github.io/?tdsourcetag=s_pctim_aiomsg

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "legado",
+  "version": "1.0.0",
+  "devDependencies": {
+    "cz-conventional-changelog": "^3.1.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  }
+}


### PR DESCRIPTION
可使用 commitizen 进行标准化 commit message 提交。

项目 commitizen 初始化步骤：

1. 使用 NVM 安装 node.js，参考：[Ubuntu 安装 Node.js 的正确姿势](https://mupceet.com/2020/02/the-best-way-to-install-nodejs/)
1. 安装 commitizen 工具：`npm install -g commitizen`
1. 在项目文件夹中执行 `npm install`

项目 commitizen 提交步骤：使用 `git cz` 替换 `git commit` 完成提交
