### PR TITLE
优化简繁体转换

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/page/ChapterProvider.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/ChapterProvider.kt
@@ -6,8 +6,10 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.RelativeSizeSpan
 import androidx.core.text.HtmlCompat
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
+import com.github.houbb.opencc4j.util.ZhConverterUtil
 import io.legado.app.App
 import io.legado.app.data.entities.BookChapter
+import io.legado.app.help.AppConfig
 import io.legado.app.lib.theme.accentColor
 
 
@@ -27,7 +29,7 @@ object ChapterProvider {
             val textPages = arrayListOf<TextPage>()
             val pageLines = arrayListOf<Int>()
             val pageLengths = arrayListOf<Int>()
-            var surplusText = content
+            var surplusText = convertChinese(content)
             var pageIndex = 0
             while (surplusText.isNotEmpty()) {
                 val spannableStringBuilder =
@@ -65,7 +67,7 @@ object ChapterProvider {
                                 lastCharNum,
                                 spannableStringBuilder.length
                             ),
-                            title = bookChapter.title,
+                            title = convertChinese(bookChapter.title),
                             chapterSize = chapterSize,
                             chapterIndex = bookChapter.index
                         )
@@ -101,4 +103,11 @@ object ChapterProvider {
     fun upReadAloudSpan() {
         readAloudSpan = ForegroundColorSpan(App.INSTANCE.accentColor)
     }
+
+    private fun convertChinese(string: String): String =
+        when (AppConfig.isChineseConverterEnable) {
+            "1" -> ZhConverterUtil.toTraditional(string)
+            "2" -> ZhConverterUtil.toSimple(string)
+            else -> string
+        }
 }

--- a/app/src/main/java/io/legado/app/ui/book/read/page/ContentView.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/ContentView.kt
@@ -9,11 +9,9 @@ import android.view.Gravity
 import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatImageView
-import com.github.houbb.opencc4j.util.ZhConverterUtil
 import io.legado.app.R
 import io.legado.app.constant.AppConst.TIME_FORMAT
 import io.legado.app.constant.PreferKey
-import io.legado.app.help.AppConfig
 import io.legado.app.help.ReadBookConfig
 import io.legado.app.utils.*
 import kotlinx.android.synthetic.main.view_book_page.view.*
@@ -113,13 +111,7 @@ class ContentView : FrameLayout {
     fun setContent(textPage: TextPage?) {
         if (textPage != null) {
             content_text_view.gravity = Gravity.START
-            content_text_view.text = if ("0" != AppConfig.isChineseConverterEnable) {
-                if ("1" == AppConfig.isChineseConverterEnable)
-                    ZhConverterUtil.toTraditional(textPage.text.toString())
-                else ZhConverterUtil.toSimple(textPage.text.toString())
-            } else {
-                textPage.text
-            }
+            content_text_view.text = textPage.text
             tv_bottom_left.text = textPage.title
             pageSize = textPage.pageSize
             setPageIndex(textPage.index)


### PR DESCRIPTION
原本是每一页加载时转换, 现改为章节加载时将未处理文字, 因为如果在每一页才加载的话加载的 String 而不是 SpannableStringBuilder, 每一章标题的样式就丢失了, 并且读书界面下面的章节名也跟着简繁转换, 界面统一