### PR TITLE
修复点击屏幕左边到下一页, 点击屏幕右边到上一页的bug

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/page/delegate/PageDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/delegate/PageDelegate.kt
@@ -279,13 +279,13 @@ abstract class PageDelegate(protected val pageView: PageView) {
                     if (!hasNext()) {
                         return true
                     }
-                    setDirection(Direction.PREV)
+                    setDirection(Direction.NEXT)
                     setBitmap()
                 } else {
                     if (!hasPrev()) {
                         return true
                     }
-                    setDirection(Direction.NEXT)
+                    setDirection(Direction.PREV)
                     setBitmap()
                 }
                 setTouchPoint(x, y)


### PR DESCRIPTION
现在在我的Xperia XZ2上表现的是点击屏幕左边到下一页, 点击屏幕右边到上一页, 应该是不符合逻辑的