### PR TITLE
修复: 每次备份都将之前的备份文件删除

### DIFF
--- a/app/src/main/java/io/legado/app/help/storage/Backup.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Backup.kt
@@ -100,12 +100,16 @@ object Backup {
             for (fileName in backupFileNames) {
                 val file = File(backupPath + File.separator + fileName)
                 if (file.exists()) {
-                    val doc = treeDoc.findFile(fileName) ?: treeDoc.createFile("", fileName)
+                    var doc = treeDoc.findFile(fileName)
+                    if (null != doc && doc.exists()) {
+                        doc.delete()
+                    }
+                    doc = treeDoc.createFile("", fileName)
                     doc?.let {
                         DocumentUtils.writeText(
                             context,
                             file.readText(),
-                            doc.uri
+                            it.uri
                         )
                     }
                 }


### PR DESCRIPTION
原本的代码, 如果已经存在的备份文件有600KB, 而将要备份的内容有500KB, 则新的备份文件还是600KB, 只有前500KB有改动, 导致不是合法的JSON格式, 从而无法还原, 例如原本有6本书, 备份之后删掉一本再备份将无法还原(Android 10)