### PR TITLE
功能添加: 选择默认字体时, 可选择字体默认字体(非衬线), 系统衬线字体, 系统等宽字体

### DIFF
--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -38,4 +38,5 @@ object PreferKey {
     const val bodyIndent = "textIndent"
     const val shareLayout = "shareLayout"
     const val readStyleSelect = "readStyleSelect"
+    const val systemTypefaces = "system_typefaces"
 }

--- a/app/src/main/java/io/legado/app/help/AppConfig.kt
+++ b/app/src/main/java/io/legado/app/help/AppConfig.kt
@@ -86,4 +86,10 @@ object AppConfig {
         set(value) {
             App.INSTANCE.putPrefInt(PreferKey.chineseConverterType, value)
         }
+
+    var systemTypefaces: Int
+        get() = App.INSTANCE.getPrefInt(PreferKey.systemTypefaces)
+        set(value) {
+            App.INSTANCE.putPrefInt(PreferKey.systemTypefaces, value)
+        }
 }

--- a/app/src/main/java/io/legado/app/ui/book/read/page/ChapterProvider.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/ChapterProvider.kt
@@ -8,6 +8,7 @@ import android.text.TextUtils
 import io.legado.app.App
 import io.legado.app.constant.PreferKey
 import io.legado.app.data.entities.BookChapter
+import io.legado.app.help.AppConfig
 import io.legado.app.help.BookHelp
 import io.legado.app.help.ReadBookConfig
 import io.legado.app.ui.book.read.page.entities.TextChapter
@@ -308,7 +309,11 @@ object ChapterProvider {
             if (!TextUtils.isEmpty(fontPath)) {
                 Typeface.createFromFile(fontPath)
             } else {
-                Typeface.SANS_SERIF
+                when (AppConfig.systemTypefaces) {
+                    1 -> Typeface.SERIF
+                    2 -> Typeface.MONOSPACE
+                    else -> Typeface.SANS_SERIF
+                }
             }
         } catch (e: Exception) {
             App.INSTANCE.removePref(PreferKey.readBookFont)

--- a/app/src/main/java/io/legado/app/ui/widget/font/FontSelectDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/font/FontSelectDialog.kt
@@ -16,7 +16,9 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import io.legado.app.App
 import io.legado.app.R
 import io.legado.app.base.BaseDialogFragment
+import io.legado.app.constant.EventBus
 import io.legado.app.constant.PreferKey
+import io.legado.app.help.AppConfig
 import io.legado.app.help.permission.Permissions
 import io.legado.app.help.permission.PermissionsCompat
 import io.legado.app.lib.dialogs.alert
@@ -89,9 +91,13 @@ class FontSelectDialog : BaseDialogFragment(),
             R.id.menu_default -> {
                 val cb = (parentFragment as? CallBack) ?: (activity as? CallBack)
                 cb?.let {
-                    if (it.curFontPath != "") {
-                        it.selectFile("")
-                    }
+                    val requireContext = requireContext()
+                    requireContext.alert(titleResource = R.string.system_typeface) {
+                        items(requireContext.resources.getStringArray(R.array.system_typefaces).toList()) { _, i ->
+                            AppConfig.systemTypefaces = i
+                            onDefaultFontChange(it)
+                        }
+                    }.show()
                 }
                 dismiss()
             }
@@ -252,6 +258,14 @@ class FontSelectDialog : BaseDialogFragment(),
                     }
                 }
             }
+        }
+    }
+
+    private fun onDefaultFontChange(callBack: CallBack){
+        if (curFilePath() == "") {
+            postEvent(EventBus.UP_CONFIG, true)
+        } else {
+            callBack.selectFile("")
         }
     }
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -152,4 +152,9 @@
         <item>简体转繁体</item>
     </string-array>
 
+    <string-array name="system_typefaces">
+        <item>系统默认字体</item>
+        <item>系统衬线字体</item>
+        <item>系统等宽等宽</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -627,4 +627,5 @@
     <string name="reduce">减</string>
     <string name="plus">加</string>
     <string name="other_aloud_setting">其它朗读设置</string>
+    <string name="system_typeface">系统内置字体样式</string>
 </resources>


### PR DESCRIPTION
Android 10 开始, 谷歌给安卓提供了思源宋体作为中日韩三文的衬线字体, 或者有些手机可以自行更改, 并且加载系统内置字体性能也更佳
![Screenshot_20200226-001624](https://user-images.githubusercontent.com/26398240/75266516-6afd9e00-582d-11ea-99d4-d8e0e9dadc96.png)
