### PR TITLE
feature: 正文加粗时, 标题使用更粗的字重

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/page/ChapterProvider.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/ChapterProvider.kt
@@ -265,7 +265,8 @@ object ChapterProvider {
         titlePaint = TextPaint()
         titlePaint.color = ReadBookConfig.durConfig.textColor()
         titlePaint.letterSpacing = ReadBookConfig.letterSpacing
-        titlePaint.typeface = Typeface.create(typeface, Typeface.BOLD)
+        titlePaint.typeface =
+            Typeface.create(typeface, if (ReadBookConfig.textBold) 900 else 700, false)
         titlePaint.textSize = with(ReadBookConfig) { textSize + titleSize }.sp.toFloat()
         titlePaint.isAntiAlias = true
         //正文


### PR DESCRIPTION
如果系统内没有该字重的字体系统会以已有字体进行加粗
引用:
https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Meaning_of_relative_weights
https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping

Signed-off-by: hingbong <hingbonglo@gmail.com>