### PR TITLE
release apk增加签名

### DIFF
--- a/.github/workflows/legado.yml
+++ b/.github/workflows/legado.yml
@@ -26,8 +26,16 @@ jobs:
         sudo apt-get -y install git
     - name: clone code
       run: |
-        git clone --depth=1 https://github.com/gedoor/legado.git /opt/legado
+        git clone https://github.com/gedoor/legado.git /opt/legado
         echo "ojbk">/opt/legado/app/src/main/assets/18PlusList.txt
+    - name: release apk sign
+      run: |
+        git clone https://github.com/10bits/gedoor-Build.git /opt/gedoor-Build
+        cp /opt/gedoor-Build/.github/workflows/legado.jks /opt/legado/app/legado.jks
+        sed '$a\RELEASE_STORE_FILE=./legado.jks' /opt/legado/gradle.properties -i 
+        sed '$a\RELEASE_KEY_ALIAS=legado' /opt/legado/gradle.properties -i
+        sed '$a\RELEASE_STORE_PASSWORD=gedoor_legado' /opt/legado/gradle.properties -i
+        sed '$a\RELEASE_KEY_PASSWORD=gedoor_legado' /opt/legado/gradle.properties -i
     - name: Build with Gradle
       run: |
         cd /opt/legado


### PR DESCRIPTION
* release apk增加签名,解决`安装失败(-102)`问题
* `与已安装应用签名不同`问题,导致的无法覆盖安装,只能卸载重新安装
* 建议提供一个公共签名文件,用于github的release apk