### PR TITLE
解决自动构建发布apk的共存

### DIFF
--- a/.github/workflows/legado.yml
+++ b/.github/workflows/legado.yml
@@ -36,6 +36,8 @@ jobs:
         sed '$a\RELEASE_KEY_ALIAS=legado' /opt/legado/gradle.properties -i
         sed '$a\RELEASE_STORE_PASSWORD=gedoor_legado' /opt/legado/gradle.properties -i
         sed '$a\RELEASE_KEY_PASSWORD=gedoor_legado' /opt/legado/gradle.properties -i
+        sed "s/'.release'/'.releaseA'/" /opt/legado/app/build.gradle -i
+        sed 's/.release/.releaseA/g' /opt/legado/app/google-services.json -i
     - name: Build with Gradle
       run: |
         cd /opt/legado


### PR DESCRIPTION
通过修改`applicationIdSuffix='.releaseA'`,解决构建发布的apk和本仓库releases apk的共存问题,不用覆盖安装了