### PR TITLE
某些书源支持设置代理访问

### DIFF
--- a/app/src/main/java/io/legado/app/help/http/HttpHelper.kt
+++ b/app/src/main/java/io/legado/app/help/http/HttpHelper.kt
@@ -8,7 +8,10 @@ import okhttp3.ConnectionSpec
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
+import okhttp3.Credentials
 import retrofit2.Retrofit
+import java.net.InetSocketAddress
+import java.net.Proxy
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 
@@ -83,6 +86,14 @@ object HttpHelper {
         return getRetrofit(baseUrl, encode).create(T::class.java)
     }
 
+    inline fun <reified T> getApiServiceWithProxy(
+        baseUrl: String,
+        encode: String? = null,
+        proxy: String? = null
+    ): T {
+        return getRetrofitWithProxy(baseUrl, encode, proxy).create(T::class.java)
+    }
+
     inline fun <reified T> getBytesApiService(baseUrl: String): T {
         return getByteRetrofit(baseUrl).create(T::class.java)
     }
@@ -92,6 +103,61 @@ object HttpHelper {
             //增加返回值为字符串的支持(以实体类返回)
             .addConverterFactory(EncodeConverter(encode))
             .client(client)
+            .build()
+    }
+
+    fun getRetrofitWithProxy(
+        baseUrl: String,
+        encode: String? = null,
+        proxy: String? = null
+    ): Retrofit {
+        val r =
+            Regex(
+                """
+                (http|socks4|socks5)://(.*):(\d{2,5})(@.*@.*)?
+                """.trimIndent()
+            )
+        val ms = proxy?.let { r.findAll(it) };
+        val group = ms?.first()
+        var type: String = "direct"     //直接连接
+        var host: String = "127.0.0.1"  //代理服务器hostname
+        var port: Int = 1080            //代理服务器port
+        var username: String = ""       //代理服务器验证用户名
+        var password: String = ""       //代理服务器验证密码
+        if (group != null) {
+            type = if (group.groupValues[1] == "http") {
+                "http"
+            } else {
+                "socks"
+            }
+            host = group.groupValues[2]
+            port = group.groupValues[3].toInt()
+            if (group.groupValues[4] != "") {
+                username = group.groupValues[4].split("@")[1];
+                password = group.groupValues[4].split("@")[2];
+            }
+        }
+        val builder = client.newBuilder();
+        if (type != "direct" && host != "") {
+            if (type == "http") {
+                builder.proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(host, port)));
+            } else {
+                builder.proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress(host, port)));
+            }
+            if (username != "" && password != "") {
+                builder.proxyAuthenticator { _, response -> //设置代理服务器账号密码
+                    val credential: String = Credentials.basic(username, password)
+                    response.request().newBuilder()
+                        .header("Proxy-Authorization", credential)
+                        .build()
+                }
+            }
+
+        }
+        return Retrofit.Builder().baseUrl(baseUrl)
+            //增加返回值为字符串的支持(以实体类返回)
+            .addConverterFactory(EncodeConverter(encode))
+            .client(builder.build())
             .build()
     }
 


### PR DESCRIPTION
### 请求头里设置,支持http代理,socks4 socks5代理
socks5代理
```json
{
  "proxy":"socks5://127.0.0.1:1080"
}
```
> 注意:这个请求头是无意义的,会被忽略掉

http代理
```json
{
  "proxy":"http://127.0.0.1:1080"
}
```
> 注意:这个请求头是无意义的,会被忽略掉

### 支持代理服务器验证
```json
{
  "proxy":"socks5://127.0.0.1:1080@用户名@密码"
}
```
> 注意:这个请求头是无意义的,会被忽略掉

### 希望可以在设置里设置代理服务器
这样可以用
```json
{
  "proxy":true
}
```
> 注意:这个请求头是无意义的,会被忽略掉