### PR TITLE
语言切换bug修复

### DIFF
--- a/app/src/main/java/io/legado/app/App.kt
+++ b/app/src/main/java/io/legado/app/App.kt
@@ -7,6 +7,7 @@ import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Build
 import android.provider.Settings
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.multidex.MultiDexApplication
@@ -46,7 +47,7 @@ class App : MultiDexApplication() {
         INSTANCE = this
         androidId = Settings.System.getString(contentResolver, Settings.Secure.ANDROID_ID)
         CrashHandler(this)
-        LanguageUtils.setConfigurationOld(this)
+        LanguageUtils.setConfiguration(this)
         db = AppDatabase.createDatabase(INSTANCE)
         packageManager.getPackageInfo(packageName, 0)?.let {
             versionCode = it.versionCode

--- a/app/src/main/java/io/legado/app/constant/EventBus.kt
+++ b/app/src/main/java/io/legado/app/constant/EventBus.kt
@@ -3,6 +3,7 @@ package io.legado.app.constant
 object EventBus {
     const val MEDIA_BUTTON = "mediaButton"
     const val RECREATE = "RECREATE"
+    const val REOPEN = "REOPEN"
     const val UP_BOOK = "upBookToc"
     const val ALOUD_STATE = "aloud_state"
     const val TTS_PROGRESS = "ttsStart"

--- a/app/src/main/java/io/legado/app/help/ActivityHelp.kt
+++ b/app/src/main/java/io/legado/app/help/ActivityHelp.kt
@@ -3,6 +3,7 @@ package io.legado.app.help
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
+import io.legado.app.utils.LanguageUtils
 import java.lang.ref.WeakReference
 import java.util.*
 
@@ -110,5 +111,8 @@ object ActivityHelp : Application.ActivityLifecycleCallbacks {
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         add(activity)
+        if (!LanguageUtils.isSameWithSetting(activity)){
+            LanguageUtils.setConfiguration(activity)
+        }
     }
 }

--- a/app/src/main/java/io/legado/app/help/storage/Restore.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Restore.kt
@@ -225,7 +225,7 @@ object Restore {
             if (!BuildConfig.DEBUG) {
                 LauncherIconHelp.changeIcon(App.INSTANCE.getPrefString(PreferKey.launcherIcon))
             }
-            LanguageUtils.setConfigurationOld(App.INSTANCE)
+            LanguageUtils.setConfiguration(App.INSTANCE)
             App.INSTANCE.applyDayNight()
             postEvent(EventBus.SHOW_RSS, "")
             postEvent(EventBus.RECREATE, "")

--- a/app/src/main/java/io/legado/app/ui/config/ConfigActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/config/ConfigActivity.kt
@@ -1,9 +1,14 @@
 package io.legado.app.ui.config
 
+import android.content.Intent
 import android.os.Bundle
+import android.os.Process
+import android.util.Log
+import io.legado.app.App
 import io.legado.app.R
 import io.legado.app.base.VMBaseActivity
 import io.legado.app.constant.EventBus
+import io.legado.app.ui.main.MainActivity
 import io.legado.app.utils.getViewModel
 import io.legado.app.utils.observeEvent
 import kotlinx.android.synthetic.main.activity_config.*
@@ -53,6 +58,13 @@ class ConfigActivity : VMBaseActivity<ConfigViewModel>(R.layout.activity_config)
         super.observeLiveBus()
         observeEvent<String>(EventBus.RECREATE) {
             recreate()
+        }
+        observeEvent<String>(EventBus.REOPEN) {
+            Log.d("h11128", "reopen")
+            val intent = Intent(App.INSTANCE, MainActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            App.INSTANCE.startActivity(intent)
+            Process.killProcess(Process.myPid())
         }
     }
 }

--- a/app/src/main/java/io/legado/app/ui/config/ConfigActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/config/ConfigActivity.kt
@@ -3,7 +3,6 @@ package io.legado.app.ui.config
 import android.content.Intent
 import android.os.Bundle
 import android.os.Process
-import android.util.Log
 import io.legado.app.App
 import io.legado.app.R
 import io.legado.app.base.VMBaseActivity
@@ -60,7 +59,6 @@ class ConfigActivity : VMBaseActivity<ConfigViewModel>(R.layout.activity_config)
             recreate()
         }
         observeEvent<String>(EventBus.REOPEN) {
-            Log.d("h11128", "reopen")
             val intent = Intent(App.INSTANCE, MainActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
             App.INSTANCE.startActivity(intent)

--- a/app/src/main/java/io/legado/app/ui/config/OtherConfigFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/config/OtherConfigFragment.kt
@@ -126,7 +126,7 @@ class OtherConfigFragment : BasePreferenceFragment(),
                 App.INSTANCE.getPrefBoolean(PreferKey.replaceEnableDefault, true)
             PreferKey.language -> {
                 LanguageUtils.setConfiguration(App.INSTANCE)
-                postEvent(EventBus.RECREATE, "")
+                postEvent(EventBus.REOPEN, "")
             }
         }
     }

--- a/app/src/main/java/io/legado/app/ui/config/OtherConfigFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/config/OtherConfigFragment.kt
@@ -7,6 +7,7 @@ import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.documentfile.provider.DocumentFile
 import androidx.preference.ListPreference
@@ -31,6 +32,7 @@ import io.legado.app.ui.widget.image.CoverImageView
 import io.legado.app.ui.widget.number.NumberPickerDialog
 import io.legado.app.utils.*
 import java.io.File
+import java.util.*
 
 
 class OtherConfigFragment : BasePreferenceFragment(),
@@ -123,7 +125,7 @@ class OtherConfigFragment : BasePreferenceFragment(),
             PreferKey.replaceEnableDefault -> AppConfig.replaceEnableDefault =
                 App.INSTANCE.getPrefBoolean(PreferKey.replaceEnableDefault, true)
             PreferKey.language -> {
-                LanguageUtils.setConfigurationOld(App.INSTANCE)
+                LanguageUtils.setConfiguration(App.INSTANCE)
                 postEvent(EventBus.RECREATE, "")
             }
         }

--- a/app/src/main/java/io/legado/app/utils/LanguageUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/LanguageUtils.kt
@@ -41,7 +41,8 @@ object LanguageUtils {
             val resources: Resources = context.resources
             val targetLocale = getSetLocale(context)
             val configuration: Configuration = resources.configuration
-            configuration.setLocale(targetLocale)
+            @Suppress("DEPRECATION")
+            configuration.locale = targetLocale
             @Suppress("DEPRECATION")
             resources.updateConfiguration(configuration, resources.displayMetrics)
         }
@@ -70,7 +71,7 @@ object LanguageUtils {
             locale = context.resources.configuration.locales[0]
         } else {
             @Suppress("DEPRECATION")
-            locale =context.resources.configuration.locale
+            locale = context.resources.configuration.locale
         }
         /*
         Log.d("h11128", "displayName " + locale.displayName)
@@ -97,7 +98,7 @@ object LanguageUtils {
     }
 
     /**
-     * 判断系统语言和设置语言是否相同
+     * 判断App语言和设置语言是否相同
      */
     fun isSameWithSetting(context: Context): Boolean {
         val locale = getAppLocale(context)

--- a/app/src/main/java/io/legado/app/utils/LanguageUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/LanguageUtils.kt
@@ -5,7 +5,6 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Build
 import android.os.LocaleList
-import android.util.Log
 import io.legado.app.constant.PreferKey
 import java.util.*
 

--- a/app/src/main/java/io/legado/app/utils/LanguageUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/LanguageUtils.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Build
+import android.os.LocaleList
+import android.util.Log
 import io.legado.app.constant.PreferKey
 import java.util.*
 
@@ -16,14 +18,14 @@ object LanguageUtils {
     fun setConfiguration(context: Context): Context {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val resources: Resources = context.resources
-            val targetLocale: Locale = when (context.getPrefString(PreferKey.language)) {
-                "zh" -> Locale.CHINESE
-                "tw" -> Locale.TRADITIONAL_CHINESE
-                "en" -> Locale.ENGLISH
-                else -> getSystemLocale()
-            }
+            val metrics = resources.displayMetrics
             val configuration: Configuration = resources.configuration
+            //Log.d("h11128", "set language to ${context.getPrefString(PreferKey.language)}")
+            val targetLocale = getSetLocale(context)
             configuration.setLocale(targetLocale)
+            configuration.setLocales(LocaleList(targetLocale))
+            @Suppress("DEPRECATION")
+            resources.updateConfiguration(configuration, metrics)
             context.createConfigurationContext(configuration)
         } else {
             setConfigurationOld(context)
@@ -34,18 +36,12 @@ object LanguageUtils {
     /**
      * 设置语言
      */
-    fun setConfigurationOld(context: Context) {
+    private fun setConfigurationOld(context: Context) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             val resources: Resources = context.resources
-            val targetLocale: Locale = when (context.getPrefString(PreferKey.language)) {
-                "zh" -> Locale.CHINESE
-                "tw" -> Locale.TRADITIONAL_CHINESE
-                "en" -> Locale.ENGLISH
-                else -> getSystemLocale()
-            }
+            val targetLocale = getSetLocale(context)
             val configuration: Configuration = resources.configuration
-            @Suppress("DEPRECATION")
-            configuration.locale = targetLocale
+            configuration.setLocale(targetLocale)
             @Suppress("DEPRECATION")
             resources.updateConfiguration(configuration, resources.displayMetrics)
         }
@@ -55,13 +51,62 @@ object LanguageUtils {
      * 当前系统语言
      */
     private fun getSystemLocale(): Locale {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) { //7.0有多语言设置获取顶部的语言
-            Resources.getSystem().configuration.locales.get(0)
+        val locale: Locale
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) { //7.0有多语言设置获取顶部的语言
+            locale = Resources.getSystem().configuration.locales.get(0)
         } else {
             @Suppress("DEPRECATION")
-            Resources.getSystem().configuration.locale
+            locale = Resources.getSystem().configuration.locale
+        }
+        return locale
+    }
+
+    /**
+     * 当前App语言
+     */
+    private fun getAppLocale(context: Context): Locale {
+        val locale: Locale
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            locale = context.resources.configuration.locales[0]
+        } else {
+            @Suppress("DEPRECATION")
+            locale =context.resources.configuration.locale
+        }
+        /*
+        Log.d("h11128", "displayName " + locale.displayName)
+        Log.d("h11128", "displayCountry " + locale.displayCountry)
+        Log.d("h11128", "displayLanguage " + locale.displayLanguage)
+        Log.d("h11128", "Language " + locale.language)
+        Log.d("h11128", "Country " + locale.country)
+
+         */
+        return locale
+
+    }
+
+    /**
+     * 当前设置语言
+     */
+    private fun getSetLocale(context: Context): Locale {
+        return when (context.getPrefString(PreferKey.language)) {
+            "zh" -> Locale.SIMPLIFIED_CHINESE
+            "tw" -> Locale.TRADITIONAL_CHINESE
+            "en" -> Locale.ENGLISH
+            else -> getSystemLocale()
         }
     }
 
+    /**
+     * 判断系统语言和设置语言是否相同
+     */
+    fun isSameWithSetting(context: Context): Boolean {
+        val locale = getAppLocale(context)
+        val language = locale.language
+        val country = locale.country
+        val pfLocale = getSetLocale(context)
+        val pfLanguage = pfLocale.language
+        val pfCountry = pfLocale.country
+        return language == pfLanguage && country == pfCountry
+    }
 
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -99,10 +99,10 @@
 	</string-array>
 
 	<string-array name="language">
-		<item>跟随系统</item>
-		<item>简体中文</item>
-		<item>繁体中文</item>
-		<item>英文</item>
+		<item>Auto</item>
+		<item>Simplified_Chinese</item>
+		<item>Traditional_Chinese</item>
+		<item>English</item>
 	</string-array>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!--App-->
     <string name="app_name">Legado</string>
@@ -693,7 +694,7 @@
     <string name="hideFooter">Hide footer</string>
     <string name="switchLayout">Switch Layout</string>
     <string name="text_font_weight_converter">Text font weight switching</string>
-  
+
     <!--color-->
     <string name="primary">Primary</string>
     <string name="accent">Accent</string>


### PR DESCRIPTION
修复了语言切换失效的bug，设置后重启APP到主页。

在设置完成后，使用REFRESH EVENT会出现首页默认分组名“全部”不改变，需要重启app才能改变。所以增加REOPEN EVENT。