### PR TITLE
增加上传至lanzouCloud的设置

### DIFF
--- a/.github/workflows/legado.yml
+++ b/.github/workflows/legado.yml
@@ -1,10 +1,10 @@
 name: Android CI
 
-on: 
+on:
   release:
     types: [published]
   push:
-    branches: 
+    branches:
       - master
 #    tags:
 #      - '3.*'
@@ -18,40 +18,73 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    env:
+      # 登录蓝奏云后查看cookie
+      # LANZOU_ID ： woozooo.com -> Cookie -> ylogin
+      # LANZOU_PSD ： pc.woozooo.com -> Cookie -> phpdisk_info
+      LANZOU_ID: ${{ secrets.LANZOU_ID }}
+      LANZOU_PSD: ${{ secrets.LANZOU_PSD }}
+      # 蓝奏云里的文件夹名（需手动在蓝奏云创建）
+      LANZOU_FOLDER: '阅读3测试版'
+      # 是否上传到artifact
+      UPLOAD_ARTIFACT: 'true'
     steps:
-    - uses: actions/checkout@v2
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: clear 18PlusList.txt
-      run: |
-        echo "清空18PlusList.txt"
-        echo "">$GITHUB_WORKSPACE/app/src/main/assets/18PlusList.txt
-    - name: release apk sign
-      run: |
-        echo "给apk增加签名"
-        cp $GITHUB_WORKSPACE/.github/workflows/legado.jks $GITHUB_WORKSPACE/app/legado.jks
-        sed '$a\RELEASE_STORE_FILE=./legado.jks'          $GITHUB_WORKSPACE/gradle.properties -i 
-        sed '$a\RELEASE_KEY_ALIAS=legado'                 $GITHUB_WORKSPACE/gradle.properties -i
-        sed '$a\RELEASE_STORE_PASSWORD=gedoor_legado'     $GITHUB_WORKSPACE/gradle.properties -i
-        sed '$a\RELEASE_KEY_PASSWORD=gedoor_legado'       $GITHUB_WORKSPACE/gradle.properties -i
-    - name: apk live together
-      run: |
-        echo "设置apk共存"
-        sed "s/'.release'/'.releaseA'/" $GITHUB_WORKSPACE/app/build.gradle  -i
-        sed 's/.release/.releaseA/'     $GITHUB_WORKSPACE/app/google-services.json -i
-    - name: build with gradle
-      run: |
-        echo "开始进行release构建"
-        chmod +x gradlew
-        ./gradlew assembleAppRelease
-    - name : upload apk
-      uses: actions/upload-artifact@master
-      if: always()
-      with:
-        name: legado apk
-        path: ${{ github.workspace }}/app/build/outputs/apk/app/release
+      - uses: actions/checkout@v2
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: clear 18PlusList.txt
+        run: |
+          echo "清空18PlusList.txt"
+          echo "">$GITHUB_WORKSPACE/app/src/main/assets/18PlusList.txt
+      - name: release apk sign
+        run: |
+          echo "给apk增加签名"
+          cp $GITHUB_WORKSPACE/.github/workflows/legado.jks $GITHUB_WORKSPACE/app/legado.jks
+          sed '$a\RELEASE_STORE_FILE=./legado.jks'          $GITHUB_WORKSPACE/gradle.properties -i
+          sed '$a\RELEASE_KEY_ALIAS=legado'                 $GITHUB_WORKSPACE/gradle.properties -i
+          sed '$a\RELEASE_STORE_PASSWORD=gedoor_legado'     $GITHUB_WORKSPACE/gradle.properties -i
+          sed '$a\RELEASE_KEY_PASSWORD=gedoor_legado'       $GITHUB_WORKSPACE/gradle.properties -i
+      - name: apk live together
+        run: |
+          echo "设置apk共存"
+          sed "s/'.release'/'.releaseA'/" $GITHUB_WORKSPACE/app/build.gradle  -i
+          sed 's/.release/.releaseA/'     $GITHUB_WORKSPACE/app/google-services.json -i
+      - name: build with gradle
+        run: |
+          echo "开始进行release构建"
+          chmod +x gradlew
+          ./gradlew assembleAppRelease
+      - name: upload apk
+        if: ${{ env.UPLOAD_ARTIFACT != 'false' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: legado apk
+          path: ${{ github.workspace }}/app/build/outputs/apk/app/release/*.apk
+      - name: Set up Python 3.8
+        if: ${{ env.LANZOU_PSD }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Set up lanzou-api
+        if: ${{ env.LANZOU_PSD }}
+        run: |
+          pip install requests
+          pip install lanzou-api
+      - name: Download Script
+        if: ${{ env.LANZOU_PSD }}
+        shell: python
+        run: |
+          import requests,os
+          res = requests.get('https://raw.githubusercontent.com/Celeter/build/master/.github/scripts/API_lanzou.py')
+          with open(os.environ["FILEPATH"], 'wb') as f:
+            f.write(res.content)
+        env:
+          FILEPATH: ${{ github.workspace }}/.github/lzy.py
+      - name: Upload App
+        if: ${{ env.LANZOU_PSD }}
+        run: python $GITHUB_WORKSPACE/.github/lzy.py
+        env:
+          UPLOAD_FOLDER: ${{ github.workspace }}/app/build/outputs/apk/app/release/


### PR DESCRIPTION
登录蓝奏云后，点击浏览器地址栏上的小锁查看cookie
![image](https://user-images.githubusercontent.com/48249130/101556548-16ab5f80-39f6-11eb-8619-26b6b087e3a1.png)

LANZOU_ID ： woozooo.com -> Cookie -> ylogin
LANZOU_PSD ： pc.woozooo.com -> Cookie -> phpdisk_info

获取到cookie后在github的secrets中增加LANZOU_ID和LANZOU_PSD
LANZOU_ID: ${{ secrets.LANZOU_ID }}
LANZOU_PSD: ${{ secrets.LANZOU_PSD }}

蓝奏云里的文件夹名（需手动在蓝奏云创建）
LANZOU_FOLDER: '阅读3测试版'

是否上传到artifact，true表示上传，false表示不上传
UPLOAD_ARTIFACT: 'true'