### PR TITLE
export .txt file using Codeset GB18030 to save storage

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/cache/CacheViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/cache/CacheViewModel.kt
@@ -15,6 +15,7 @@ import io.legado.app.help.storage.BookWebDav
 import io.legado.app.utils.*
 import splitties.init.appCtx
 import java.io.File
+import java.nio.charset.Charset
 
 
 class CacheViewModel(application: Application) : BaseViewModel(application) {
@@ -67,7 +68,7 @@ class CacheViewModel(application: Application) : BaseViewModel(application) {
     private suspend fun export(file: File, book: Book) {
         val filename = "${book.name} by ${book.author}.txt"
         FileUtils.createFileIfNotExist(file, filename)
-            .writeText(getAllContents(book))
+            .writeText(getAllContents(book), Charset.forName("GB18030"))
         if (appCtx.getPrefBoolean(PreferKey.webDavCacheBackup, false)) {
             BookWebDav.exportWebDav(file.absolutePath, filename) // 导出到webdav
         }


### PR DESCRIPTION
  UTF-8 and GB18030 are two dialects of Unicode. All code points are completely equivalent.
  However, if the document is completely Chinese, using GB18030 can save 1/3 of the storage space, a 3MB UTF-8 encoded .txt Chinese file , It only needs 2MB storage space to convert to GB18030 encoding.
我手机的中文小说.txt文件全是GB18030编码的，比起UTF-8编码的要省不少空间（300MB vs 200MB），两种编码的码点是Unicode全映射的，不会缺字丢字，包括emoji。
目前用阅读3.0导出的.txt是UTF-8，而手机上不方便转码成GB18030，所以改了下导出参数，直接存成GB18030编码。