### PR TITLE
1.修复漫画崩溃问题；2.修复书签溢出屏幕问题；3.epub书籍增加本地cache，加速加载速度

### DIFF
--- a/app/src/main/java/io/legado/app/help/BookHelp.kt
+++ b/app/src/main/java/io/legado/app/help/BookHelp.kt
@@ -148,7 +148,7 @@ object BookHelp {
 
     fun getChapterFiles(book: Book): List<String> {
         val fileNameList = arrayListOf<String>()
-        if (book.isLocalBook()) {
+        if (book.isLocalTxt()) {
             return fileNameList
         }
         FileUtils.createFolderIfNotExist(
@@ -162,7 +162,7 @@ object BookHelp {
 
     // 检测该章节是否下载
     fun hasContent(book: Book, bookChapter: BookChapter): Boolean {
-        return if (book.isLocalBook()) {
+        return if (book.isLocalTxt()) {
             true
         } else {
             FileUtils.exists(
@@ -175,8 +175,19 @@ object BookHelp {
     }
 
     fun getContent(book: Book, bookChapter: BookChapter): String? {
-        if (book.isLocalBook()) {
+        if (book.isLocalTxt()) {
             return LocalBook.getContext(book, bookChapter)
+        } else if (book.isEpub() && !hasContent(book, bookChapter)) {
+            val string = LocalBook.getContext(book, bookChapter)
+            string?.let {
+                FileUtils.createFileIfNotExist(
+                    downloadDir,
+                    cacheFolderName,
+                    book.getFolderName(),
+                    bookChapter.getFileName(),
+                ).writeText(it)
+            }
+            return string
         } else {
             val file = FileUtils.getFile(
                 downloadDir,
@@ -211,7 +222,7 @@ object BookHelp {
     }
 
     fun delContent(book: Book, bookChapter: BookChapter) {
-        if (book.isLocalBook()) {
+        if (book.isLocalTxt()) {
             return
         } else {
             FileUtils.createFileIfNotExist(

--- a/app/src/main/java/io/legado/app/ui/book/read/page/provider/ImageProvider.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/provider/ImageProvider.kt
@@ -61,6 +61,7 @@ object ImageProvider {
         }
     }
 
+    @Synchronized
     fun clearAllCache() {
         cache.forEach { indexCache ->
             indexCache.value.forEach {
@@ -70,6 +71,7 @@ object ImageProvider {
         cache.clear()
     }
 
+    @Synchronized
     fun clearOut(chapterIndex: Int) {
         cache.forEach { indexCache ->
             if (indexCache.key !in chapterIndex - 1..chapterIndex + 1) {

--- a/app/src/main/java/io/legado/app/ui/book/toc/BookmarkFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/BookmarkFragment.kt
@@ -88,6 +88,10 @@ class BookmarkFragment : VMBaseFragment<ChapterListViewModel>(R.layout.fragment_
             val alertBinding = DialogBookmarkBinding.inflate(layoutInflater).apply {
                 editBookText.setText(bookmark.bookText)
                 editView.setText(bookmark.content)
+                editBookText.textSize = 15f
+                editView.textSize = 15f
+                editBookText.maxLines= 6
+                editView.maxLines= 6
             }
             customView { alertBinding.root }
             yesButton {


### PR DESCRIPTION
1.问题1是图片cache没保护好，看漫画切目录切书籍很容易signal 11崩溃，建议合并。
2.问题2不知道是不是我手机的问题，书签内容显示过多时按钮会溢出屏幕无法按，修改为锁定内容行数。看看要不要合并。
3.问题3主要是一些epub书籍加载速度很慢（比如一个html文件有N个章节）。章节内容解析后存在本地，可以加速2次打开速度。看看要不要合并。