### PR TITLE
解决全面屏手势与阅读翻页冲突

### DIFF
--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -72,6 +72,7 @@ object PreferKey {
     const val exportCharset = "exportCharset"
     const val exportUseReplace = "exportUseReplace"
     const val useZhLayout = "useZhLayout"
+    const val fullScreenGesturesSupport = "fullScreenGesturesSupport"
 
     const val cPrimary = "colorPrimary"
     const val cAccent = "colorAccent"

--- a/app/src/main/java/io/legado/app/help/AppConfig.kt
+++ b/app/src/main/java/io/legado/app/help/AppConfig.kt
@@ -190,6 +190,9 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
 
     val replaceEnableDefault get() = appCtx.getPrefBoolean(PreferKey.replaceEnableDefault, true)
 
+    val fullScreenGesturesSupport: Boolean
+        get () = appCtx.getPrefBoolean(PreferKey.fullScreenGesturesSupport, false)
+
     private fun getPrefUserAgent(): String {
         val ua = appCtx.getPrefString(PreferKey.userAgent)
         if (ua.isNullOrBlank()) {

--- a/app/src/main/java/io/legado/app/ui/book/read/config/MoreConfigDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/MoreConfigDialog.kt
@@ -16,6 +16,7 @@ import io.legado.app.help.ReadBookConfig
 import io.legado.app.lib.theme.ATH
 import io.legado.app.lib.theme.bottomBackground
 import io.legado.app.ui.book.read.ReadBookActivity
+import io.legado.app.ui.book.read.page.ReadView
 import io.legado.app.utils.dp
 import io.legado.app.utils.getPrefBoolean
 import io.legado.app.utils.postEvent
@@ -126,6 +127,9 @@ class MoreConfigDialog : DialogFragment() {
                 "customPageKey" -> PageKeyDialog(requireContext()).show()
                 "clickRegionalConfig" -> {
                     (activity as? ReadBookActivity)?.showClickRegionalConfig()
+                }
+                "fullScreenGesturesSupport" -> {
+                    ((activity as? ReadBookActivity)?.findViewById(R.id.read_view) as ReadView).setRect9x()
                 }
             }
             return super.onPreferenceTreeClick(preference)

--- a/app/src/main/java/io/legado/app/ui/book/read/page/ReadView.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/ReadView.kt
@@ -77,15 +77,15 @@ class ReadView(context: Context, attrs: AttributeSet) :
     private var firstCharIndex: Int = 0
 
     val slopSquare by lazy { ViewConfiguration.get(context).scaledTouchSlop }
-    private val tlRect = RectF(0f, 0f, width * 0.33f, height * 0.33f)
-    private val tcRect = RectF(width * 0.33f, 0f, width * 0.66f, height * 0.33f)
-    private val trRect = RectF(width * 0.36f, 0f, width - 0f, height * 0.33f)
-    private val mlRect = RectF(0f, height * 0.33f, width * 0.33f, height * 0.66f)
-    private val mcRect = RectF(width * 0.33f, height * 0.33f, width * 0.66f, height * 0.66f)
-    private val mrRect = RectF(width * 0.66f, height * 0.33f, width - 0f, height * 0.66f)
-    private val blRect = RectF(0f, height * 0.66f, width * 0.33f, height - 0f)
-    private val bcRect = RectF(width * 0.33f, height * 0.66f, width * 0.66f, height - 0f)
-    private val brRect = RectF(width * 0.66f, height * 0.66f, width - 0f, height - 0f)
+    private val tlRect = RectF()
+    private val tcRect = RectF()
+    private val trRect = RectF()
+    private val mlRect = RectF()
+    private val mcRect = RectF()
+    private val mrRect = RectF()
+    private val blRect = RectF()
+    private val bcRect = RectF()
+    private val brRect = RectF()
     private val autoPageRect by lazy { Rect() }
     private val autoPagePint by lazy { Paint().apply { color = context.accentColor } }
     private val boundary by lazy { BreakIterator.getWordInstance(Locale.getDefault()) }
@@ -99,19 +99,25 @@ class ReadView(context: Context, attrs: AttributeSet) :
             setWillNotDraw(false)
             upPageAnim()
         }
+        setRect9x()
+    }
+
+    public fun setRect9x() {
+        val edge = if (AppConfig.fullScreenGesturesSupport) { 200f } else { 0f }
+        tlRect.set(0f + edge, 0f, width * 0.33f, height * 0.33f)
+        tcRect.set(width * 0.33f, 0f, width * 0.66f, height * 0.33f)
+        trRect.set(width * 0.36f, 0f, width - 0f - edge, height * 0.33f)
+        mlRect.set(0f + edge, height * 0.33f, width * 0.33f, height * 0.66f)
+        mcRect.set(width * 0.33f, height * 0.33f, width * 0.66f, height * 0.66f)
+        mrRect.set(width * 0.66f, height * 0.33f, width - 0f - edge, height * 0.66f)
+        blRect.set(0f + edge, height * 0.66f, width * 0.33f, height - 10f - edge)
+        bcRect.set(width * 0.33f, height * 0.66f, width * 0.66f, height - 0f - edge)
+        brRect.set(width * 0.66f, height * 0.66f, width - 0f - edge, height - 0f - edge)
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
-        tlRect.set(0f, 0f, width * 0.33f, height * 0.33f)
-        tcRect.set(width * 0.33f, 0f, width * 0.66f, height * 0.33f)
-        trRect.set(width * 0.36f, 0f, width - 0f, height * 0.33f)
-        mlRect.set(0f, height * 0.33f, width * 0.33f, height * 0.66f)
-        mcRect.set(width * 0.33f, height * 0.33f, width * 0.66f, height * 0.66f)
-        mrRect.set(width * 0.66f, height * 0.33f, width - 0f, height * 0.66f)
-        blRect.set(0f, height * 0.66f, width * 0.33f, height - 10f)
-        bcRect.set(width * 0.33f, height * 0.66f, width * 0.66f, height - 0f)
-        brRect.set(width * 0.66f, height * 0.66f, width - 0f, height - 0f)
+        setRect9x()
         prevPage.x = -w.toFloat()
         pageDelegate?.setViewSize(w, h)
     }

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -680,6 +680,7 @@
     <string name="middle">中</string>
     <string name="information">信息</string>
     <string name="switchLayout">切換佈局</string>
+    <string name="full_screen_gestures_support">全面屏手勢支援</string>
 
     <!--color-->
     <string name="primary">主色調</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -680,7 +680,7 @@
     <string name="middle">中</string>
     <string name="information">信息</string>
     <string name="switchLayout">切換佈局</string>
-    <string name="full_screen_gestures_support">全面屏手勢支援</string>
+    <string name="full_screen_gestures_support">全面屏手勢優化</string>
 
     <!--color-->
     <string name="primary">主色調</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -693,7 +693,7 @@
     <string name="information">訊息</string>
     <string name="switchLayout">切換布局</string>
     <string name="text_font_weight_converter">文章字重轉換</string>
-    <string name="full_screen_gestures_support">全面屏手勢支援</string>
+    <string name="full_screen_gestures_support">全面屏手勢優化</string>
   
     <!--color-->
     <string name="primary">主色調</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -693,6 +693,7 @@
     <string name="information">訊息</string>
     <string name="switchLayout">切換布局</string>
     <string name="text_font_weight_converter">文章字重轉換</string>
+    <string name="full_screen_gestures_support">全面屏手勢支援</string>
   
     <!--color-->
     <string name="primary">主色調</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -693,7 +693,7 @@
     <string name="information">信息</string>
     <string name="switchLayout">切换布局</string>
     <string name="text_font_weight_converter">文章字重切换</string>
-    <string name="full_screen_gestures_support">全面屏手势支持</string>
+    <string name="full_screen_gestures_support">全面屏手势优化</string>
 
     <!--color-->
     <string name="primary">主色调</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -693,6 +693,7 @@
     <string name="information">信息</string>
     <string name="switchLayout">切换布局</string>
     <string name="text_font_weight_converter">文章字重切换</string>
+    <string name="full_screen_gestures_support">全面屏手势支持</string>
 
     <!--color-->
     <string name="primary">主色调</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -694,6 +694,7 @@
     <string name="information">Information</string>
     <string name="switchLayout">Switch Layout</string>
     <string name="text_font_weight_converter">Text font weight switching</string>
+    <string name="full_screen_gestures_support">Full screen gestures support</string>
 
     <!--color-->
     <string name="primary">Primary</string>

--- a/app/src/main/res/xml/pref_config_read.xml
+++ b/app/src/main/res/xml/pref_config_read.xml
@@ -103,6 +103,13 @@
         app:iconSpaceReserved="false"
         app:isBottomBackground="true" />
 
+    <io.legado.app.ui.widget.prefs.SwitchPreference
+        android:defaultValue="false"
+        android:key="fullScreenGesturesSupport"
+        android:title="@string/full_screen_gestures_support"
+        app:iconSpaceReserved="false"
+        app:isBottomBackground="true" />
+
     <io.legado.app.ui.widget.prefs.Preference
         android:key="customPageKey"
         android:title="@string/custom_page_key"


### PR DESCRIPTION
解决 issue #914
增加了一个默认关闭的可选开关“全面屏手势优化”，全面屏手势用户可以开启该选项，使用系统手势时，触碰阅读文字屏幕左右边沿和下沿时不会触发翻页功能。
九宫格的左右下三个边沿7个区块相应缩小范围。