### PR TITLE
索引可作为首规则，此时相当于前面有个`children`。简化切分规则，并修复切分规则时重复压入的问题。

### DIFF
--- a/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeByJSoup.kt
+++ b/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeByJSoup.kt
@@ -213,7 +213,7 @@ class AnalyzeByJSoup(doc: Any) {
         val curList = mutableListOf<Int?>() //当前数字区间
         var l = "" //暂存数字字符串
 
-        val head = rus[rus.length-1] == ']' //是否为常规索引写法
+        val head = rus.last() == ']' //是否为常规索引写法
 
         if(head){ //常规索引写法[index...]
 
@@ -236,7 +236,7 @@ class AnalyzeByJSoup(doc: Any) {
 
                         else -> {
 
-                            //为保证查找顺序，区间和单个索引都添加到同一集合 
+                            //为保证查找顺序，区间和单个索引都添加到同一集合
                             if(curList.isEmpty())indexSet.indexs.add(curInt!!)
                             else{
 
@@ -265,7 +265,7 @@ class AnalyzeByJSoup(doc: Any) {
                     curMinus = false //重置
                 }
             }
-        } else while (len --> 1) { //阅读原本写法，逆向遍历,至少两位前置字符,如 p.
+        } else while (len --> 0) { //阅读原本写法，逆向遍历,至少两位前置字符,如 .
 
             val rl = rus[len]
             if (rl == ' ') continue //跳过空格
@@ -314,8 +314,9 @@ class AnalyzeByJSoup(doc: Any) {
         val rules = ruleStr.split(".")
 
         elements.addAll(
-            when (rules[0]) {
-                "children" -> temp.children()
+            if(ruleStr.isEmpty()) temp.children() //允许索引直接作为根元素，此时前置规则为空，效果与children相同
+            else when (rules[0]) {
+                "children" -> temp.children() //允许索引直接作为根元素，此时前置规则为空，效果与children相同
                 "class" -> temp.getElementsByClass(rules[1])
                 "tag" -> temp.getElementsByTag(rules[1])
                 "id" -> Collector.collect(Evaluator.Id(rules[1]), temp)

--- a/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeByJSoup.kt
+++ b/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeByJSoup.kt
@@ -219,7 +219,7 @@ class AnalyzeByJSoup(doc: Any) {
 
             len-- //跳过尾部']'
 
-            while (len-- > 0) { //逆向遍历,至少有一位前置字符,如 [
+            while (len-- >= 0) { //逆向遍历,可以无前置规则
 
                 var rl = rus[len]
                 if (rl == ' ') continue //跳过空格
@@ -265,7 +265,7 @@ class AnalyzeByJSoup(doc: Any) {
                     curMinus = false //重置
                 }
             }
-        } else while (len --> 0) { //阅读原本写法，逆向遍历,至少两位前置字符,如 .
+        } else while (len-- >= 0) { //阅读原本写法，逆向遍历,可以无前置规则
 
             val rl = rus[len]
             if (rl == ' ') continue //跳过空格

--- a/app/src/main/java/io/legado/app/model/analyzeRule/RuleAnalyzer.kt
+++ b/app/src/main/java/io/legado/app/model/analyzeRule/RuleAnalyzer.kt
@@ -255,7 +255,7 @@ class RuleAnalyzer(data: String) {
 
     /**
      * 不用正则,不到最后不切片也不用中间变量存储,只在序列中标记当前查找字段的开头结尾,到返回时才切片,高效快速准确切割规则
-     * 解决jsonPath自带的"&&"和"||"与阅读的规则冲突,以及规则正则或字符串中包含"&&"或"||"或"%%"而导致的冲突
+     * 解决jsonPath自带的"&&"和"||"与阅读的规则冲突,以及规则正则或字符串中包含"&&"、"||"、"%%"、"@"导致的冲突
      */
     tailrec fun splitRule(vararg split: String): Array<String>{ //首段匹配,elementsType为空
 
@@ -284,7 +284,7 @@ class RuleAnalyzer(data: String) {
             return rule
         }
 
-        val rule = if(st >pos ){ //先匹配到st1pos，表明"&&","||"不在选择器中，将选择器前"&&","||"分隔的字段依次压入数组
+        val rule = if(st >pos ){ //先匹配到st1pos，表明分隔字串不在选择器中，将选择器前分隔字串分隔的字段依次压入数组
 
             var rule = arrayOf(queue.substring(0, pos)) //压入分隔的首段规则到数组
 
@@ -337,7 +337,7 @@ class RuleAnalyzer(data: String) {
             return rule
         }
 
-        val rule = if(st > pos ){//先匹配到st1pos，表明"&&","||"不在选择器中，将选择器前"&&","||"分隔的字段依次压入数组
+        val rule = if(st > pos ){//先匹配到st1pos，表明分隔字串不在选择器中，将选择器前分隔字串分隔的字段依次压入数组
             var rule = rules + queue.substring(start, pos) //压入本次分隔的首段规则到数组
             pos += step //跳过分隔符
             while (consumeTo(elementsType) && pos < st) { //循环切分规则压入数组

--- a/app/src/main/java/io/legado/app/model/analyzeRule/RuleAnalyzer.kt
+++ b/app/src/main/java/io/legado/app/model/analyzeRule/RuleAnalyzer.kt
@@ -98,9 +98,9 @@ class RuleAnalyzer(data: String) {
     }
 
     /**
-     * 从剩余字串中拉出一个字符串，直到且包括匹配序列（匹配参数列表中一项即为匹配），或剩余字串用完。
+     * 从剩余字串中拉出一个字符串，直到但不包括匹配序列（匹配参数列表中一项即为匹配），或剩余字串用完。
      * @param seq 匹配字符串序列
-     * @return 成功返回true并推移pos，失败返回fasle而不推移pos
+     * @return 成功返回true并设置间隔，失败则直接返回fasle
      */
     fun consumeToAny(vararg seq:String): Boolean {
 
@@ -126,7 +126,7 @@ class RuleAnalyzer(data: String) {
     /**
      * 从剩余字串中拉出一个字符串，直到但不包括匹配序列（匹配参数列表中一项即为匹配），或剩余字串用完。
      * @param seq 匹配字符序列
-     * @return 匹配到的位置
+     * @return 返回匹配位置
      */
     private fun findToAny(vararg seq:Char): Int {
 


### PR DESCRIPTION
1. `AnalyzeByJSoup`：允许索引作为首规则，等价于前面有个`children`。

`head@[1]@text` 与 `head@children[1]@text` 与  `head@.1@text` 三者等价

2. `RuleAnalyzer`：简化其中部分规则，调整压入切分出的规则时的判断顺序，解决之前的重复压入问题。