### PR TITLE
修复bug

### DIFF
--- a/app/src/main/java/io/legado/app/constant/AppPattern.kt
+++ b/app/src/main/java/io/legado/app/constant/AppPattern.kt
@@ -9,7 +9,7 @@ object AppPattern {
     val EXP_PATTERN: Pattern = Pattern.compile("\\{\\{([\\w\\W]*?)\\}\\}")
 
     //匹配格式化后的图片格式
-    val imgPattern: Pattern = Pattern.compile("<img[^>]*src=\"([^\"]*(?:,\\{[^>]+\\})?)\"[^>]*>")
+    val imgPattern: Pattern = Pattern.compile("<img[^>]*src=\"([^\"]*(?:\"[^>]+\\})?)\"[^>]*>")
 
     val nameRegex = Regex("\\s+作\\s*者.*|\\s+\\S+\\s+著")
     val authorRegex = Regex("^.*?作\\s*者[:：\\s]*|\\s+著")


### PR DESCRIPTION
将“[^"]*”之后的正则更改为"开头，避免出现前面的正则抢占后面正则匹配的序列，导致带参数的图片“捕获分组1”得到的链接不包含全部参数的问题。