### PR TITLE
修正epub导出时图片文字混合格式错误

### DIFF
--- a/app/src/main/java/io/legado/app/ui/rss/read/ReadRssActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/rss/read/ReadRssActivity.kt
@@ -37,7 +37,7 @@ class ReadRssActivity : VMBaseActivity<ActivityRssReadBinding, ReadRssViewModel>
 
     override val binding by viewBinding(ActivityRssReadBinding::inflate)
     override val viewModel by viewModels<ReadRssViewModel>()
-    private val imagePathKey = ""
+    private val imagePathKey = "imagePath"
     private var starMenuItem: MenuItem? = null
     private var ttsMenuItem: MenuItem? = null
     private var customWebViewCallback: WebChromeClient.CustomViewCallback? = null
@@ -155,8 +155,16 @@ class ReadRssActivity : VMBaseActivity<ActivityRssReadBinding, ReadRssViewModel>
     }
 
     private fun saveImage() {
+        val path = ACache.get(this@ReadRssActivity).getAsString(imagePathKey)
+        if (path.isNullOrEmpty()) {
+            selectExportFolder()
+        } else {
+            viewModel.saveImage(webPic, path)
+        }
+    }
+    private fun selectExportFolder() {
         val default = arrayListOf<String>()
-        val path = ACache.get(this).getAsString(imagePathKey)
+        val path = ACache.get(this@ReadRssActivity).getAsString(imagePathKey)
         if (!path.isNullOrEmpty()) {
             default.add(path)
         }

--- a/epublib/src/main/java/me/ag2s/epublib/util/StringUtil.java
+++ b/epublib/src/main/java/me/ag2s/epublib/util/StringUtil.java
@@ -279,10 +279,10 @@ public class StringUtil {
         for (String s : text.split("\\r?\\n")) {
             s = s.replaceAll("^\\s+|\\s+$", "");
             if (s.length() > 0) {
-                if (s.toLowerCase().contains("<img")) {
-                    s = s.replaceAll("(?i)<img\\s([^>]+)/?>", "<div class=\"duokan-image-single\"><img class=\"picture-80\" $1/></div>");
-                }
-                if (!(s.startsWith("<div") && s.endsWith("</div>"))) {
+                //段落为一张图片才认定为图片章节/漫画并启用多看单图优化，否则认定为普通文字夹杂着的图片文字。
+                if (s.matches("(?i)^<img\\s([^>]+)/?>$")) {
+                    body.append(s.replaceAll("(?i)^<img\\s([^>]+)/?>$", "<div class=\"duokan-image-single\"><img class=\"picture-80\" $1/></div>"));                }
+                else{
                     body.append("<p>").append(s).append("</p>");
                 }
             }


### PR DESCRIPTION
1. 修正epub导出时图片文字混合格式错误：多看单图优化不适用于所有场景，缩小有效范围为段落单图，提高兼容性。\<p\>内包含\<div\>不合规范，修改以符合规范。
2. 修正订阅里保存图片总是要选择保存路径的BUG