### PR TITLE
Update AnalyzeRule.kt

### DIFF
--- a/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeRule.kt
+++ b/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeRule.kt
@@ -436,16 +436,16 @@ class AnalyzeRule(val ruleData: RuleDataInterface) : JsExtensions {
                     mode = Mode.XPath
                     ruleStr.substring(7)
                 }
-                ruleStr.startsWith("/") -> {//XPath特征很明显,无需配置单独的识别标头
-                    mode = Mode.XPath
-                    ruleStr
-                }
                 ruleStr.startsWith("@Json:", true) -> {
                     mode = Mode.Json
                     ruleStr.substring(6)
                 }
                 isJSON || ruleStr.startsWith("$.") || ruleStr.startsWith("$[") -> {
                     mode = Mode.Json
+                    ruleStr
+                }
+                ruleStr.startsWith("/") -> {//XPath特征很明显,无需配置单独的识别标头
+                    mode = Mode.XPath
                     ruleStr
                 }
                 else -> ruleStr


### PR DESCRIPTION
isJSON为真时先替换内嵌{$.}，再考虑是否为XPath，避免XPath写法与链接写法冲突。
注：链接可以用//或/开头。
一般链接要么通过规则获取，要么包含内嵌规则，非发现处直接写个固定链接的书源比较少，意义也通常是站位