### PR TITLE
换源界面功能添加：置顶，置底，删除

### DIFF
--- a/app/src/main/java/io/legado/app/data/dao/SearchBookDao.kt
+++ b/app/src/main/java/io/legado/app/data/dao/SearchBookDao.kt
@@ -1,9 +1,6 @@
 package io.legado.app.data.dao
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room.*
 import io.legado.app.data.entities.SearchBook
 
 @Dao
@@ -62,4 +59,9 @@ interface SearchBookDao {
     @Query("delete from searchBooks where time < :time")
     fun clearExpired(time: Long)
 
+    @Update
+    fun update(vararg searchBook: SearchBook)
+
+    @Delete
+    fun delete(vararg searchBook: SearchBook)
 }

--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeSourceAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeSourceAdapter.kt
@@ -88,6 +88,16 @@ class ChangeSourceAdapter(
                 R.id.menu_disable_book_source -> {
                     callBack.disableSource(searchBook)
                 }
+                R.id.menu_top_source -> {
+                    callBack.topSource(searchBook)
+                }
+                R.id.menu_bottom_source -> {
+                    callBack.bottomSource(searchBook)
+                }
+                R.id.menu_delete_book_source -> {
+                    callBack.deleteSource(searchBook)
+                    updateItems(0, itemCount, listOf<Int>())
+                }
             }
             true
         }
@@ -98,5 +108,8 @@ class ChangeSourceAdapter(
         val bookUrl: String?
         fun changeTo(searchBook: SearchBook)
         fun disableSource(searchBook: SearchBook)
+        fun topSource(searchBook: SearchBook)
+        fun bottomSource(searchBook: SearchBook)
+        fun deleteSource(searchBook: SearchBook)
     }
 }

--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeSourceDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeSourceDialog.kt
@@ -194,9 +194,7 @@ class ChangeSourceDialog : BaseDialogFragment(),
     }
 
     override fun changeTo(searchBook: SearchBook) {
-        val book = searchBook.toBook()
-        book.upInfoFromOld(callBack?.oldBook)
-        callBack?.changeTo(book)
+        changeSource(searchBook)
         dismissAllowingStateLoss()
     }
 
@@ -205,6 +203,31 @@ class ChangeSourceDialog : BaseDialogFragment(),
 
     override fun disableSource(searchBook: SearchBook) {
         viewModel.disableSource(searchBook)
+    }
+
+    override fun topSource(searchBook: SearchBook) {
+        viewModel.topSource(searchBook)
+    }
+
+    override fun bottomSource(searchBook: SearchBook) {
+        viewModel.bottomSource(searchBook)
+    }
+
+    override fun deleteSource(searchBook: SearchBook) {
+        if (bookUrl == searchBook.bookUrl) {
+            viewModel.firstSourceOrNull(searchBook)?.let {
+                changeSource(it)
+            }
+        }
+        viewModel.del(searchBook)
+    }
+
+    private fun changeSource(searchBook: SearchBook) {
+        val book = searchBook.toBook()
+        book.upInfoFromOld(callBack?.oldBook)
+        callBack?.changeTo(book)
+        searchBook.time = System.currentTimeMillis()
+        viewModel.updateSource(searchBook)
     }
 
     /**

--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeSourceViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeSourceViewModel.kt
@@ -240,4 +240,49 @@ class ChangeSourceViewModel(application: Application) : BaseViewModel(applicatio
         }
     }
 
+    fun topSource(searchBook: SearchBook) {
+        execute {
+            appDb.bookSourceDao.getBookSource(searchBook.origin)?.let { source ->
+                val minOrder = appDb.bookSourceDao.minOrder - 1
+                source.customOrder = minOrder
+                searchBook.originOrder = source.customOrder
+                appDb.bookSourceDao.update(source)
+                updateSource(searchBook)
+            }
+            upAdapter()
+        }
+    }
+
+    fun bottomSource(searchBook: SearchBook) {
+        execute {
+            appDb.bookSourceDao.getBookSource(searchBook.origin)?.let { source ->
+                val maxOrder = appDb.bookSourceDao.maxOrder + 1
+                source.customOrder = maxOrder
+                searchBook.originOrder = source.customOrder
+                appDb.bookSourceDao.update(source)
+                updateSource(searchBook)
+            }
+            upAdapter()
+        }
+    }
+
+    fun updateSource(searchBook: SearchBook) {
+        appDb.searchBookDao.update(searchBook)
+    }
+
+    fun del(searchBook: SearchBook) {
+        execute {
+            appDb.bookSourceDao.getBookSource(searchBook.origin)?.let { source ->
+                appDb.bookSourceDao.delete(source)
+                appDb.searchBookDao.delete(searchBook)
+            }
+        }
+        searchBooks.remove(searchBook)
+        upAdapter()
+    }
+
+    fun firstSourceOrNull(searchBook: SearchBook): SearchBook? {
+        return searchBooks.firstOrNull { it.bookUrl != searchBook.bookUrl }
+    }
+
 }

--- a/app/src/main/res/menu/change_source_item.xml
+++ b/app/src/main/res/menu/change_source_item.xml
@@ -2,7 +2,19 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
+        android:id="@+id/menu_top_source"
+        android:title="@string/to_top" />
+
+    <item
+        android:id="@+id/menu_bottom_source"
+        android:title="@string/to_bottom" />
+
+    <item
         android:id="@+id/menu_disable_book_source"
         android:title="@string/disable_book_source" />
+
+    <item
+        android:id="@+id/menu_delete_book_source"
+        android:title="@string/delete" />
 
 </menu>


### PR DESCRIPTION
换源界面功能添加：置顶，置底，删除

删除当前书源可以自动切换其他书源，一直没想出怎么更新打钩号，就先这样了。

https://user-images.githubusercontent.com/22561041/127806118-b681840d-d38f-4f7d-bde1-736f57626c8b.mp4



