### PR TITLE
统一release和cronet的版本号，并加上“分”，以区别同时段的多个commit

### DIFF
--- a/.github/workflows/legado.yml
+++ b/.github/workflows/legado.yml
@@ -50,6 +50,9 @@ jobs:
           echo "设置apk共存"
           sed "s/'.release'/'.releaseA'/" $GITHUB_WORKSPACE/app/build.gradle  -i
           sed 's/.release/.releaseA/'     $GITHUB_WORKSPACE/app/google-services.json -i
+          echo "统一版本号"
+          version=$(date -d "8 hour" -u +3.%y.%m%d%H%M)
+          sed "/def version/c def version = \"$version\"" $GITHUB_WORKSPACE/app/build.gradle  -i
       - name: Build With Gradle
         run: |
           echo "开始进行release构建"


### PR DESCRIPTION
已在miui上测试通过，可从原版本号正常升级到新版本号