### PR TITLE
Update BookController.kt

### DIFF
--- a/app/src/main/java/io/legado/app/api/controller/BookController.kt
+++ b/app/src/main/java/io/legado/app/api/controller/BookController.kt
@@ -177,7 +177,7 @@ object BookController {
     }
 
     private fun saveBookReadIndex(book: Book, index: Int) {
-        if (index > book.durChapterIndex) {
+        if (index != book.durChapterIndex) {
             book.durChapterIndex = index
             book.durChapterTime = System.currentTimeMillis()
             appDb.bookChapterDao.getChapter(book.bookUrl, index)?.let {


### PR DESCRIPTION
web端的index大于app端的index, app才会更新index.
导致在web上跳转到过往的章节, app上阅读记录不变动