### PR TITLE
解决无法备份恢复旧版书源的问题

### DIFF
--- a/app/src/main/java/io/legado/app/help/storage/ImportOldData.kt
+++ b/app/src/main/java/io/legado/app/help/storage/ImportOldData.kt
@@ -92,7 +92,7 @@ object ImportOldData {
         return books.size
     }
 
-    private fun importOldSource(json: String): Int {
+    fun importOldSource(json: String): Int {
         val bookSources = mutableListOf<BookSource>()
         val items: List<Map<String, Any>> = Restore.jsonPath.parse(json).read("$")
         for (item in items) {

--- a/app/src/main/java/io/legado/app/help/storage/Restore.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Restore.kt
@@ -125,6 +125,10 @@ object Restore {
             }
             fileToListT<BookSource>(path, "bookSource.json")?.let {
                 appDb.bookSourceDao.insert(*it.toTypedArray())
+            } ?: run {
+                val bookSourceFile = FileUtils.createFileIfNotExist(path + File.separator + "bookSource.json")
+                val json = bookSourceFile.readText()
+                ImportOldData.importOldSource(json)
             }
             fileToListT<RssSource>(path, "rssSources.json")?.let {
                 appDb.rssSourceDao.insert(*it.toTypedArray())


### PR DESCRIPTION
前几天刚更新了bookSource的属性，然后发现一个暴露出的edge case:

如果用户在没有更新的app备份，然后在有更新booksource属性的app恢复那个备份文件，那么备份恢复书源会直接失效，因为书源属性发生改变，而现有的函数没有处理旧版书源的代码。

这个pr解决这个问题。

https://user-images.githubusercontent.com/22561041/131268117-fb30c65a-44eb-4876-8e64-9fb2cd9fb996.mp4

