### PR TITLE
将已缓存章节加粗显示修改为未缓存章节加粗显示，更易于辨认

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/toc/ChapterListAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/ChapterListAdapter.kt
@@ -75,7 +75,7 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
 
     private fun upHasCache(binding: ItemChapterListBinding, isDur: Boolean, cached: Boolean) =
         binding.apply {
-            tvChapterName.paint.isFakeBoldText = cached
+            tvChapterName.paint.isFakeBoldText = !cached
             ivChecked.setImageResource(R.drawable.ic_outline_cloud_24)
             ivChecked.visible(!cached)
             if (isDur) {


### PR DESCRIPTION
加粗显示的文字会吸引注意力，目录页展开的时候更多的是想查看后续未阅读的章节，修改后的目录页，应该方便一些
![目录页](https://user-images.githubusercontent.com/5535801/147828245-1633029f-6c4c-47fb-83a2-ff19b25b78f5.png)
