### PR TITLE
优化getSubDomain：链接为ip时直接返回

### DIFF
--- a/app/src/main/java/io/legado/app/utils/NetworkUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/NetworkUtils.kt
@@ -144,10 +144,24 @@ object NetworkUtils {
         } else url.substring(0, index)
     }
 
+    /**
+     * 获取二级域名，供cookie保存和读取
+     * 
+     * 1.2.3.4 => 1.2.3.4
+     * www.example.com =>  example.com
+     * www.example.com.cn => example.com.cn
+     * 未实现www.content.example.com => example.com
+     */
     fun getSubDomain(url: String?): String {
         val baseUrl = getBaseUrl(url) ?: return ""
+        //baseUrl为IPv4时，直接返回
+        //IPv6暂时不考虑支持
+        if (isIPv4Address(baseUrl)) {
+            return baseUrl
+        }
+        //td do:利用https://github.com/publicsuffix/list，https://github.com/Kevin-Sangeelee/PublicSuffixList实现二级域名返回
         return if (baseUrl.indexOf(".") == baseUrl.lastIndexOf(".")) {
-            baseUrl.substring(baseUrl.lastIndexOf("/") + 1)
+            baseUrl
         } else baseUrl.substring(baseUrl.indexOf(".") + 1)
     }
 


### PR DESCRIPTION
相关 https://github.com/gedoor/legado/pull/337

可以根据反馈看是否要用[publicsuffix_list](https://github.com/publicsuffix/list) 或者[public_suffix_list.dat](https://publicsuffix.org/list/public_suffix_list.dat) 来识别二级域名，目前方法只是简单的切割，没有考虑'com.cn'之类次级域名的情况

[使用参考](https://github.com/Kevin-Sangeelee/PublicSuffixList)