### PR TITLE
初步支持二级目录;拼接链接函数优化

### DIFF
--- a/app/src/main/assets/web/bookSource/index.html
+++ b/app/src/main/assets/web/bookSource/index.html
@@ -251,6 +251,11 @@
                           placeholder="选择章节链接 (规则结果为String类型的Url)"></textarea>
             </div>
             <div>
+                <div>Volume标识:</div>
+                <textarea rows="1" id="ruleToc_isVolume" class="ruleToc" title="isVolume"
+                          placeholder="章节名称是否是卷名 (规则结果为Bool)"></textarea>
+            </div>
+            <div>
                 <div>收费标识:</div>
                 <textarea rows="1" id="ruleToc_isVip" class="ruleToc" title="isVip"
                           placeholder="章节是否为VIP章节 (规则结果为Bool)"></textarea>

--- a/app/src/main/java/io/legado/app/data/AppDatabase.kt
+++ b/app/src/main/java/io/legado/app/data/AppDatabase.kt
@@ -16,7 +16,7 @@ val appDb by lazy {
 }
 
 @Database(
-    version = 42,
+    version = 43,
     exportSchema = true,
     entities = [Book::class, BookGroup::class, BookSource::class, BookChapter::class,
         ReplaceRule::class, SearchBook::class, SearchKeyword::class, Cookie::class,

--- a/app/src/main/java/io/legado/app/data/DatabaseMigrations.kt
+++ b/app/src/main/java/io/legado/app/data/DatabaseMigrations.kt
@@ -38,7 +38,8 @@ object DatabaseMigrations {
             migration_38_39,
             migration_39_40,
             migration_40_41,
-            migration_41_42
+            migration_41_42,
+            migration_42_43
         )
     }
 
@@ -334,6 +335,12 @@ object DatabaseMigrations {
     private val migration_41_42 = object : Migration(41, 42) {
         override fun migrate(database: SupportSQLiteDatabase) {
             database.execSQL("ALTER TABLE 'httpTTS' ADD `contentType` TEXT")
+        }
+    }
+
+    private val migration_42_43 = object : Migration(42, 43) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("ALTER TABLE `chapters` ADD `isVolume` INTEGER NOT NULL DEFAULT 0")
         }
     }
 }

--- a/app/src/main/java/io/legado/app/data/entities/BookChapter.kt
+++ b/app/src/main/java/io/legado/app/data/entities/BookChapter.kt
@@ -33,6 +33,7 @@ import splitties.init.appCtx
 data class BookChapter(
     var url: String = "",               // 章节地址
     var title: String = "",             // 章节标题
+    var isVolume: Boolean = false,    // 是否是卷名
     var baseUrl: String = "",           // 用来拼接相对url
     var bookUrl: String = "",           // 书籍地址
     var index: Int = 0,                 // 章节序号

--- a/app/src/main/java/io/legado/app/data/entities/rule/TocRule.kt
+++ b/app/src/main/java/io/legado/app/data/entities/rule/TocRule.kt
@@ -8,6 +8,7 @@ data class TocRule(
     var chapterList: String? = null,
     var chapterName: String? = null,
     var chapterUrl: String? = null,
+    var isVolume: String? = null,
     var isVip: String? = null,
     var isPay: String? = null,
     var updateTime: String? = null,

--- a/app/src/main/java/io/legado/app/lib/theme/ThemeUtils.kt
+++ b/app/src/main/java/io/legado/app/lib/theme/ThemeUtils.kt
@@ -2,6 +2,7 @@ package io.legado.app.lib.theme
 
 import android.content.Context
 import androidx.annotation.AttrRes
+import android.graphics.drawable.Drawable
 
 /**
  * @author Aidan Follestad (afollestad)
@@ -27,6 +28,16 @@ object ThemeUtils {
             a.getFloat(0, fallback)
         } catch (e: Exception) {
             fallback
+        } finally {
+            a.recycle()
+        }
+    }
+
+    @JvmOverloads
+    fun resolveDrawable(context: Context, @AttrRes attr: Int): Drawable? {
+        val a = context.theme.obtainStyledAttributes(intArrayOf(attr))
+        return try {
+            a.getDrawable(0)
         } finally {
             a.recycle()
         }

--- a/app/src/main/java/io/legado/app/model/webBook/BookChapterList.kt
+++ b/app/src/main/java/io/legado/app/model/webBook/BookChapterList.kt
@@ -177,6 +177,7 @@ object BookChapterList {
             val vipRule = analyzeRule.splitSourceRule(tocRule.isVip)
             val payRule = analyzeRule.splitSourceRule(tocRule.isPay)
             val upTimeRule = analyzeRule.splitSourceRule(tocRule.updateTime)
+            val isVolumeRule = analyzeRule.splitSourceRule(tocRule.isVolume)
             elements.forEachIndexed { index, item ->
                 scope.ensureActive()
                 analyzeRule.setContent(item)
@@ -185,9 +186,19 @@ object BookChapterList {
                 bookChapter.title = analyzeRule.getString(nameRule)
                 bookChapter.url = analyzeRule.getString(urlRule)
                 bookChapter.tag = analyzeRule.getString(upTimeRule)
+                val isVolume = analyzeRule.getString(isVolumeRule)
+                bookChapter.isVolume = false
+                if (isVolume.isNotEmpty() && !isVolume.matches(falseRegex)) {
+                    bookChapter.isVolume = true
+                }
                 if (bookChapter.url.isEmpty()) {
-                    bookChapter.url = baseUrl
-                    Debug.log(bookSource.bookSourceUrl, "目录${index}未获取到url,使用baseUrl替代")
+                    if (bookChapter.isVolume) {
+                        bookChapter.url = bookChapter.title
+                        Debug.log(bookSource.bookSourceUrl, "目录${index}(Volume)未获取到url,使用章节标题替代")
+                    } else {
+                        bookChapter.url = baseUrl
+                        Debug.log(bookSource.bookSourceUrl, "目录${index}未获取到url,使用baseUrl替代")
+                    }
                 }
                 if (bookChapter.title.isNotEmpty()) {
                     val isVip = analyzeRule.getString(vipRule)

--- a/app/src/main/java/io/legado/app/model/webBook/WebBook.kt
+++ b/app/src/main/java/io/legado/app/model/webBook/WebBook.kt
@@ -261,6 +261,8 @@ object WebBook {
             Debug.log(bookSource.bookSourceUrl, "⇒正文规则为空,使用章节链接:${bookChapter.url}")
             return bookChapter.url
         }
+        //章节名为卷名时 且 章节url没获取到，返回空白
+        if(bookChapter.isVolume && bookChapter.url == bookChapter.title) return ""
         return if (bookChapter.url == book.bookUrl && !book.tocHtml.isNullOrEmpty()) {
             BookContent.analyzeContent(
                 scope = scope,

--- a/app/src/main/java/io/legado/app/ui/book/read/page/provider/ChapterProvider.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/provider/ChapterProvider.kt
@@ -566,6 +566,7 @@ object ChapterProvider {
         tPaint.typeface = titleFont
         tPaint.textSize = with(ReadBookConfig) { textSize + titleSize }.sp.toFloat()
         tPaint.isAntiAlias = true
+        //to do:卷名的标题排版
         val cPaint = TextPaint()
         cPaint.color = ReadBookConfig.textColor
         cPaint.letterSpacing = ReadBookConfig.letterSpacing

--- a/app/src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditActivity.kt
@@ -265,6 +265,7 @@ class BookSourceEditActivity :
             add(EditEntity("chapterList", tr?.chapterList, R.string.rule_chapter_list))
             add(EditEntity("chapterName", tr?.chapterName, R.string.rule_chapter_name))
             add(EditEntity("chapterUrl", tr?.chapterUrl, R.string.rule_chapter_url))
+            add(EditEntity("isVolume", tr?.isVolume, R.string.rule_is_volume))
             add(EditEntity("updateTime", tr?.updateTime, R.string.rule_update_time))
             add(EditEntity("isVip", tr?.isVip, R.string.rule_is_vip))
             add(EditEntity("isPay", tr?.isPay, R.string.rule_is_pay))
@@ -360,6 +361,7 @@ class BookSourceEditActivity :
                 "chapterList" -> tocRule.chapterList = it.value
                 "chapterName" -> tocRule.chapterName = it.value
                 "chapterUrl" -> tocRule.chapterUrl = it.value
+                "isVolume" -> tocRule.isVolume = it.value
                 "updateTime" -> tocRule.updateTime = it.value
                 "isVip" -> tocRule.isVip = it.value
                 "isPay" -> tocRule.isPay = it.value

--- a/app/src/main/java/io/legado/app/ui/book/toc/ChapterListAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/ChapterListAdapter.kt
@@ -9,9 +9,11 @@ import io.legado.app.base.adapter.RecyclerAdapter
 import io.legado.app.data.entities.BookChapter
 import io.legado.app.databinding.ItemChapterListBinding
 import io.legado.app.lib.theme.accentColor
+import io.legado.app.lib.theme.backgroundColor
+import io.legado.app.lib.theme.ThemeUtils
+import io.legado.app.help.AppConfig
 import io.legado.app.utils.getCompatColor
 import io.legado.app.utils.visible
-
 
 class ChapterListAdapter(context: Context, val callback: Callback) :
     RecyclerAdapter<BookChapter, ItemChapterListBinding>(context) {
@@ -30,6 +32,7 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
                     && oldItem.isPay == newItem.isPay
                     && oldItem.title == newItem.title
                     && oldItem.tag == newItem.tag
+                    && oldItem.isVolume == newItem.isVolume
         }
 
     }
@@ -54,7 +57,15 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
                     tvChapterName.setTextColor(context.getCompatColor(R.color.primaryText))
                 }
                 tvChapterName.text = item.getDisplayTitle()
-                if (!item.tag.isNullOrEmpty()) {
+                if (item.isVolume) {
+                    //卷名，如第一卷 突出显示
+                    tvChapterItem.setBackgroundColor(context.getCompatColor(R.color.btn_bg_press))
+                } else {
+                    //普通章节 保持不变
+                    tvChapterItem.setBackground(ThemeUtils.resolveDrawable(context, android.R.attr.selectableItemBackground))
+                }
+                if (!item.tag.isNullOrEmpty() && !item.isVolume) {
+                //卷名不显示tag(更新时间规则)
                     tvTag.text = item.tag
                     tvTag.visible()
                 }

--- a/app/src/main/java/io/legado/app/utils/NetworkUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/NetworkUtils.kt
@@ -109,6 +109,7 @@ object NetworkUtils {
     fun getAbsoluteURL(baseURL: String?, relativePath: String): String {
         if (baseURL.isNullOrEmpty()) return relativePath
         if (relativePath.isAbsUrl()) return relativePath
+        if (relativePath.startsWith("javascript")) return ""
         var relativeUrl = relativePath
         try {
             val absoluteUrl = URL(baseURL.substringBefore(","))
@@ -126,6 +127,7 @@ object NetworkUtils {
      */
     fun getAbsoluteURL(baseURL: URL?, relativePath: String): String {
         if (baseURL == null) return relativePath
+        if (relativePath.startsWith("javascript")) return ""
         var relativeUrl = relativePath
         try {
             val parseUrl = URL(baseURL, relativePath)

--- a/app/src/main/res/layout/item_chapter_list.xml
+++ b/app/src/main/res/layout/item_chapter_list.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
+    android:id="@+id/tv_chapter_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -414,6 +414,7 @@
     <string name="rule_chapter_list">目录列表规则(chapterList)</string>
     <string name="rule_chapter_name">章节名称规则(ChapterName)</string>
     <string name="rule_chapter_url">章节URL规则(chapterUrl)</string>
+    <string name="rule_is_volume">Volume mark(isVolume)</string>
     <string name="rule_is_vip">VIP标识(isVip)</string>
     <string name="rule_update_time">更新时间(ChapterInfo)</string>
     <string name="rule_book_content">正文规则(content)</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -418,6 +418,7 @@
     <string name="rule_chapter_list">目录列表规则(chapterList)</string>
     <string name="rule_chapter_name">章节名称规则(ChapterName)</string>
     <string name="rule_chapter_url">章节URL规则(chapterUrl)</string>
+    <string name="rule_is_volume">Volume mark(isVolume)</string>
     <string name="rule_is_vip">VIP标识(isVip)</string>
     <string name="rule_update_time">更新时间(ChapterInfo)</string>
     <string name="rule_book_content">正文规则(content)</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -413,6 +413,7 @@
     <string name="rule_chapter_list">目錄列表規則 (chapterList)</string>
     <string name="rule_chapter_name">章節名稱規則 (ChapterName)</string>
     <string name="rule_chapter_url">章節 URL 規則 (chapterUrl)</string>
+    <string name="rule_is_volume">Volume標識(isVolume)</string>
     <string name="rule_is_vip">VIP 標識 (isVip)</string>
     <string name="rule_update_time">更新時間 (ChapterInfo)</string>
     <string name="rule_book_content">正文規則 (content)</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -417,6 +417,7 @@
     <string name="rule_chapter_list">目錄列表規則(chapterList)</string>
     <string name="rule_chapter_name">章節名稱規則(ChapterName)</string>
     <string name="rule_chapter_url">章節URL規則(chapterUrl)</string>
+    <string name="rule_is_volume">Volume標識(isVolume)</string>
     <string name="rule_is_vip">VIP標識(isVip)</string>
     <string name="rule_update_time">更新時間(ChapterInfo)</string>
     <string name="rule_book_content">正文規則(content)</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -417,6 +417,7 @@
     <string name="rule_chapter_list">目录列表规则(chapterList)</string>
     <string name="rule_chapter_name">章节名称规则(ChapterName)</string>
     <string name="rule_chapter_url">章节URL规则(chapterUrl)</string>
+    <string name="rule_is_volume">Volume标识(isVolume)</string>
     <string name="rule_is_vip">VIP标识(isVip)</string>
     <string name="rule_update_time">更新时间(ChapterInfo)</string>
     <string name="rule_book_content">正文规则(content)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -418,6 +418,7 @@
     <string name="rule_chapter_list">目录列表规则(chapterList)</string>
     <string name="rule_chapter_name">章节名称规则(ChapterName)</string>
     <string name="rule_chapter_url">章节URL规则(chapterUrl)</string>
+    <string name="rule_is_volume">Volume标识(isVolume)</string>
     <string name="rule_is_vip">VIP标识(isVip)</string>
     <string name="rule_update_time">更新时间(ChapterInfo)</string>
     <string name="rule_book_content">正文规则(content)</string>


### PR DESCRIPTION
#986 完成部分
> 已完成
* 添加规则isVolume
* 二级目录突出显示

> 未完成
* 卷url为空时，正文标题正中显示
* ~~链接为空时显示卷下面的章节名~~

[使用的书源](https://shuyuan.miaogongzi.cc/shuyuan/12e1bdba9e3744358668193407384612.json) 

![二级目录效果](https://user-images.githubusercontent.com/82232510/148733188-e826d25c-c148-4e4d-9ce3-b04e3fb558db.jpg)


