### PR TITLE
使用阿里云Maven镜像作为下载源

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,7 @@
 buildscript {
     ext.kotlin_version = '1.6.10'
     repositories {
-        google()
-        mavenCentral()
-        maven { url 'https://plugins.gradle.org/m2/' }
+        maven { url 'https://maven.aliyun.com/repository/google' }
         maven { url 'https://maven.aliyun.com/repository/public' }
         maven { url 'https://maven.aliyun.com/repository/gradle-plugin' }
     }
@@ -19,8 +17,7 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
-        mavenCentral()
+        maven { url 'https://maven.aliyun.com/repository/google' }
         maven { url 'https://maven.aliyun.com/repository/public' }
         maven { url 'https://jitpack.io' }
     }


### PR DESCRIPTION
查看[阿里云云效Maven使用指南](https://developer.aliyun.com/mvn/guide)，可以完成以下替换：

1. google() => https://maven.aliyun.com/repository/google
2. mavenCentral() => https://maven.aliyun.com/repository/public
3. https://plugins.gradle.org/m2/ => https://maven.aliyun.com/repository/gradle-plugin

综上，去除项目中重复的下载源，以及替换 google()