### PR TITLE
TXT初始化目录时不应启用已关闭的规则

### DIFF
--- a/app/src/main/java/io/legado/app/model/localBook/TextFile.kt
+++ b/app/src/main/java/io/legado/app/model/localBook/TextFile.kt
@@ -307,7 +307,7 @@ class TextFile(private val book: Book) {
      */
     private fun getTocRule(content: String): Pattern? {
         tocRules.addAll(getTocRules(content, getTocRules().reversed()))
-        tocRules.addAll(getTocRules(content, appDb.txtTocRuleDao.disabled.reversed()))
+        //tocRules.addAll(getTocRules(content, appDb.txtTocRuleDao.disabled.reversed()))
         return tocRules.firstOrNull()
     }
 


### PR DESCRIPTION
**默认关闭或用户自行关闭的规则** 可能并不适用于所有类型的书籍，应当由用户**手动点选规则**进行处理。初始化目录时不应当启用已关闭的规则。通常已关闭的规则比较**激进**，在一些情况下适配的目录数量_远高于其他规则_，会造成自动识别规则错误。也是最近用户反映目录问题的主要原因。

一些启用已关闭的规则造成目录自动识别错误的例子：
![464778f93285492924da193d777e72786ef47b22f525f5e8](https://user-images.githubusercontent.com/32198215/152359382-486d7bdd-9d49-439e-b341-92dbf298b597.jpeg)
![_959528495_Screenshot_2022-02-03-21-56-20-263_com](https://user-images.githubusercontent.com/32198215/152359404-8955d61b-72ce-4a09-a09f-36e4882424ee.jpg)

请根据情况选择是否合并该PR，若合并应该在更新日志处加以注明，以提醒用户注意识别规则的变化。