### PR TITLE
优化书籍详情页某些菜单的显示

### DIFF
--- a/app/src/main/java/io/legado/app/api/controller/BookController.kt
+++ b/app/src/main/java/io/legado/app/api/controller/BookController.kt
@@ -7,6 +7,7 @@ import io.legado.app.api.ReturnData
 import io.legado.app.constant.PreferKey
 import io.legado.app.data.appDb
 import io.legado.app.data.entities.Book
+import io.legado.app.help.AppConfig
 import io.legado.app.help.BookHelp
 import io.legado.app.help.CacheManager
 import io.legado.app.help.ContentProcessor
@@ -206,7 +207,8 @@ object BookController {
                 ?: return returnData.setErrorMsg("fileName 不能为空")
             val fileData = parameters["fileData"]?.firstOrNull()
                 ?: return returnData.setErrorMsg("fileData 不能为空")
-            val file = FileUtils.createFileIfNotExist(LocalBook.cacheFolder, fileName)
+            if (AppConfig.defaultBookTreeUri == null) return returnData.setErrorMsg("没有设置书籍保存位置!")
+            val file = FileUtils.createFileIfNotExist(AppConfig.defaultBookTreeUri!!, fileName)
             val fileBytes = Base64.decode(fileData.substringAfter("base64,"), Base64.DEFAULT)
             file.writeBytes(fileBytes)
             val nameAuthor = LocalBook.analyzeNameAuthor(fileName)

--- a/app/src/main/java/io/legado/app/model/localBook/LocalBook.kt
+++ b/app/src/main/java/io/legado/app/model/localBook/LocalBook.kt
@@ -24,11 +24,6 @@ import javax.script.SimpleBindings
 
 object LocalBook {
 
-    private const val folderName = "bookTxt"
-    val cacheFolder: File by lazy {
-        FileUtils.createFolderIfNotExist(appCtx.externalFiles, folderName)
-    }
-
     @Throws(FileNotFoundException::class, SecurityException::class)
     fun getBookInputStream(book: Book): InputStream {
         val uri = Uri.parse(book.bookUrl)
@@ -168,15 +163,6 @@ object LocalBook {
 
     fun deleteBook(book: Book, deleteOriginal: Boolean) {
         kotlin.runCatching {
-            if (book.isLocalTxt() || book.isUmd()) {
-                cacheFolder.getFile(book.originName).delete()
-            }
-            if (book.isEpub()) {
-                FileUtils.delete(
-                    cacheFolder.getFile(book.getFolderName())
-                )
-            }
-
             if (deleteOriginal) {
                 if (book.bookUrl.isContentScheme()) {
                     val uri = Uri.parse(book.bookUrl)

--- a/app/src/main/java/io/legado/app/ui/book/info/BookInfoActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/info/BookInfoActivity.kt
@@ -127,8 +127,10 @@ class BookInfoActivity :
             viewModel.bookSource != null
         menu.findItem(R.id.menu_set_book_variable)?.isVisible =
             viewModel.bookSource != null
+        menu.findItem(R.id.menu_can_update)?.isVisible =
+            viewModel.bookSource != null
         menu.findItem(R.id.menu_limit_content_length)?.isVisible =
-            viewModel.bookSource == null
+            viewModel.bookData.value?.isLocalTxt() ?: false
         return super.onMenuOpened(featureId, menu)
     }
 


### PR DESCRIPTION
`限制正文长度`目前只有txt文件有效
`允许更新`只对在线书籍有效
由于不再拷贝本地书副本，删除了部分代码
