### PR TITLE
pr提交也会触发action进入test build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -127,11 +128,12 @@ jobs:
         run: mv */*.apk . ;rm -rf */
       - name: Push To "test" Branch
         run: |
+          cd $GITHUB_WORKSPACE/apk/
+          git init
+          git checkout -b test
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git clone "https://${{ github.actor }}:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.actor }}/release" -b test test-branch
-          mv -f $GITHUB_WORKSPACE/apk/*.apk test-branch
-          cd test-branch
+          git remote add origin "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.actor }}/release"
           git add *.apk
           git commit -m "${{ needs.prepare.outputs.versionL }}"
           git push -f -u origin test


### PR DESCRIPTION
1. pr的提交也会触发test build；
2. test分支不保存历史记录，以免git clone进度太慢，可以到蓝奏、电报或者action的artifact下载相应的test build