### PR TITLE
双页增加判断 当屏幕比例大于3：4也开启双页，用于适配折叠屏

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/page/provider/ChapterProvider.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/provider/ChapterProvider.kt
@@ -624,7 +624,7 @@ object ChapterProvider {
      * 更新绘制尺寸
      */
     fun upLayout() {
-        doublePage = (viewWidth > viewHeight || appCtx.isPad)
+        doublePage = (((viewWidth.toFloat() / viewHeight.toFloat()) > 0.75) || appCtx.isPad)
             && ReadBook.pageAnim() != 3
             && AppConfig.doublePageHorizontal
         if (viewWidth > 0 && viewHeight > 0) {


### PR DESCRIPTION
双页增加判断：当屏幕比例大于3：4也开启双页，用于适配折叠屏竖屏双页

kotlin新手，请斟酌此处强转判断是否符合规范
[涉及文件]：ChapterProvider.kt

Signed-off-by: exa160 <sfy111@hotmail.com>