### PR TITLE
修复UI的一些bug，保存书架状态，修改添加网址的order

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -147,6 +147,7 @@
         <!-- 主界面 -->
         <activity
             android:name=".ui.main.MainActivity"
+            android:configChanges="locale|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|uiMode"
             android:alwaysRetainTaskState="true"
             android:launchMode="singleTask" />
         <!-- 阅读界面 -->

--- a/app/src/main/java/io/legado/app/App.kt
+++ b/app/src/main/java/io/legado/app/App.kt
@@ -3,6 +3,7 @@ package io.legado.app
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.os.Build
 import androidx.multidex.MultiDexApplication
@@ -28,8 +29,11 @@ import java.util.concurrent.TimeUnit
 
 class App : MultiDexApplication() {
 
+    private lateinit var oldConfig: Configuration
+
     override fun onCreate() {
         super.onCreate()
+        oldConfig = Configuration(resources.configuration)
         CrashHandler(this)
         //预下载Cronet so
         CronetLoader.preDownload()
@@ -69,10 +73,11 @@ class App : MultiDexApplication() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        when (newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK) {
-            Configuration.UI_MODE_NIGHT_YES,
-            Configuration.UI_MODE_NIGHT_NO -> applyDayNight(this)
+        val diff = newConfig.diff(oldConfig)
+        if ((diff and ActivityInfo.CONFIG_UI_MODE) != 0) {
+            applyDayNight(this)
         }
+        oldConfig = Configuration(newConfig)
     }
 
     /**

--- a/app/src/main/java/io/legado/app/ui/main/bookshelf/BookshelfViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/main/bookshelf/BookshelfViewModel.kt
@@ -50,7 +50,7 @@ class BookshelfViewModel(application: Application) : BaseViewModel(application) 
                     )
                     WebBook.getBookInfo(this, bookSource, book)
                         .onSuccess(IO) {
-                            it.order = appDb.bookDao.maxOrder + 1
+                            it.order = appDb.bookDao.minOrder - 1
                             it.save()
                             successCount++
                         }.onError {


### PR DESCRIPTION
1、修复了设备配置信息改变时（主要是屏幕旋转）会调用更新UI主题的函数导致MainActivity重载的bug。
相关 issue https://github.com/gedoor/legado/issues/1631
2、使MainActivity不再因为屏幕旋转而重载，防止书架位置状态丢失。
3、在MainActivity意外重载时保存书架位置状态，在加载书架完成后恢复。
4、修复了从添加网址处添加书籍时会添加到底部的bug。
5、修复了屏幕旋转时MainActivity重载导致的书架自动刷新（开启自动刷新功能）。