### PR TITLE
修改了换源界面的默认排序方式为按最新章节排序，方便在大量书源中手动选择最优源。

### DIFF
--- a/app/src/main/java/io/legado/app/data/dao/SearchBookDao.kt
+++ b/app/src/main/java/io/legado/app/data/dao/SearchBookDao.kt
@@ -31,7 +31,7 @@ interface SearchBookDao {
         from searchBooks as t1 inner join book_sources as t2 
         on t1.origin = t2.bookSourceUrl 
         where t1.name = :name and t1.author like '%'||:author||'%' 
-        and originName like '%'||:key||'%' and t2.enabled = 1 
+        and latestChapterTitle like '%'||:key||'%' and t2.enabled = 1 
         and t2.bookSourceGroup like '%'||:sourceGroup||'%'
         order by t2.customOrder"""
     )

--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceViewModel.kt
@@ -83,7 +83,7 @@ open class ChangeBookSourceViewModel(application: Application) : BaseViewModel(a
             searchCallback = null
         }
     }.map {
-        searchBooks.sortedBy { it.originOrder }
+        searchBooks.sortedBy { it.latestChapterTitle }
     }.flowOn(IO)
 
     @Volatile


### PR DESCRIPTION
修改了换源界面中搜索按钮的目标为各书源的最新章节（原来是过滤书源名）。