### PR TITLE
fixed bug: TextView setting 'textIsSelectable=true' make click is invalid

### DIFF
--- a/app/src/main/res/layout/item_read_record.xml
+++ b/app/src/main/res/layout/item_read_record.xml
@@ -12,7 +12,6 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:padding="6dp"
-        android:textIsSelectable="true"
         android:textColor="@color/primaryText"
         android:singleLine="true"
         app:layout_constraintLeft_toLeftOf="parent"


### PR DESCRIPTION

修复 "我的 - 阅读记录" 列表 点击 "书名区域" 没有点击事件响应的问题