### PR TITLE
修复webDav的exists函数对文件夹始终返回false的bug

### DIFF
--- a/app/src/main/java/io/legado/app/lib/webdav/WebDav.kt
+++ b/app/src/main/java/io/legado/app/lib/webdav/WebDav.kt
@@ -171,7 +171,16 @@ open class WebDav(val path: String, val authorization: Authorization) {
      * 文件是否存在
      */
     suspend fun exists(): Boolean {
-        return getWebDavFile() != null
+        return kotlin.runCatching {
+            val requestPropsStr = DIR.replace("%s", "")
+            return okHttpClient.newCallResponse {
+                url(url)
+                addHeader(authorization.name, authorization.data)
+                addHeader("Depth", "0")
+                val requestBody = requestPropsStr.toRequestBody("application/xml".toMediaType())
+                method("PROPFIND", requestBody)
+            }.code == 207
+        }.getOrDefault(false)
     }
 
     /**


### PR DESCRIPTION
parseBody函数把文件夹过滤掉了，其返回的list永远为空。