### PR TITLE
fix: 继续修复自建WebDav服务使用WebDav书籍的BUG

### DIFF
--- a/app/src/main/java/io/legado/app/lib/webdav/WebDavFile.kt
+++ b/app/src/main/java/io/legado/app/lib/webdav/WebDavFile.kt
@@ -13,10 +13,10 @@ class WebDavFile(
     val contentType: String,
     val resourceType: String,
     val lastModify: Long
-) : WebDav(urlStr, authorization) {
+    ) : WebDav(urlStr, authorization) {
 
-    val isDir by lazy {
-        contentType == "httpd/unix-directory" || resourceType.lowercase() == "<d:collection />"
-    }
+        val isDir by lazy {
+            contentType == "httpd/unix-directory" || resourceType.lowercase().contains("collection")
+        }
 
 }


### PR DESCRIPTION
1. 对列表项为文件夹的 resourceType 判断方式修改为更加细致的判断
2. 修复 caddy 服务自建 webdav 文件夹路径后缀引发的无法获取文件夹项的 BUG
3.对文件存在性的判断逻辑