### PR TITLE
修复preUpdateJs规则执行后bookUrl改变导致的一些问题

### DIFF
--- a/app/src/main/java/io/legado/app/help/BookHelp.kt
+++ b/app/src/main/java/io/legado/app/help/BookHelp.kt
@@ -39,6 +39,12 @@ object BookHelp {
         FileUtils.delete(filePath)
     }
 
+    fun updateCacheFolder(oldBook: Book, newBook: Book) {
+        val oldFolderPath = FileUtils.getPath(downloadDir, cacheFolderName, oldBook.getFolderName())
+        val newFolderPath = FileUtils.getPath(downloadDir, cacheFolderName, newBook.getFolderName())
+        FileUtils.move(oldFolderPath, newFolderPath)
+    }
+
     /**
      * 清除已删除书的缓存
      */

--- a/app/src/main/java/io/legado/app/ui/book/info/BookInfoActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/info/BookInfoActivity.kt
@@ -216,9 +216,9 @@ class BookInfoActivity :
                             toastOnUi(getString(R.string.upload_book_success))
                         else
                             toastOnUi(getString(R.string.upload_book_fail))
-                    }catch (e : Exception){
+                    } catch (e: Exception) {
                         toastOnUi(e.localizedMessage)
-                    }finally {
+                    } finally {
                         waitDialog.dismiss()
                     }
                 }
@@ -271,6 +271,8 @@ class BookInfoActivity :
                     } else {
                         binding.tvToc.text = getString(R.string.toc_s, chapterList.last().title)
                     }
+                    binding.tvLasted.text =
+                        getString(R.string.lasted_show, chapterList.last().title)
                 }
             }
         }

--- a/app/src/main/java/io/legado/app/ui/main/MainViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainViewModel.kt
@@ -11,6 +11,7 @@ import io.legado.app.data.appDb
 import io.legado.app.data.entities.Book
 import io.legado.app.data.entities.BookSource
 import io.legado.app.help.AppWebDav
+import io.legado.app.help.BookHelp
 import io.legado.app.help.DefaultData
 import io.legado.app.help.config.AppConfig
 import io.legado.app.help.config.LocalConfig
@@ -116,6 +117,7 @@ class MainViewModel(application: Application) : BaseViewModel(application) {
         waitUpTocBooks.remove(bookUrl)
         upTocAdd(bookUrl)
         execute(context = upTocPool) {
+            val oldBook = book.copy()
             val preUpdateJs = source.ruleToc?.preUpdateJs
             if (!preUpdateJs.isNullOrBlank()) {
                 AnalyzeRule(book, source).evalJS(preUpdateJs)
@@ -129,8 +131,9 @@ class MainViewModel(application: Application) : BaseViewModel(application) {
             } else {
                 upTocAdd(book.bookUrl)
                 appDb.bookDao.insert(book)
+                BookHelp.updateCacheFolder(oldBook, book)
             }
-            appDb.bookChapterDao.delByBook(book.bookUrl)
+            appDb.bookChapterDao.delByBook(bookUrl)
             appDb.bookChapterDao.insert(*toc.toTypedArray())
             addDownload(source, book)
         }.onError(upTocPool) {


### PR DESCRIPTION
1、修复手动更新目录后章节无法插入到数据库的bug（bookUrl外键报错）
2、修复bookUrl改变后导致书籍缓存丢失的问题
3、修复在详情页更新章节目录更新后，”最新“一栏的章节名字没有更新的bug