### PR TITLE
修复ReadBookActivity在一些第三方ROM上启动失败的bug

### DIFF
--- a/app/src/main/java/io/legado/app/ui/widget/seekbar/VerticalSeekBar.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/seekbar/VerticalSeekBar.kt
@@ -69,7 +69,7 @@ class VerticalSeekBar @JvmOverloads constructor(context: Context, attrs: Attribu
         }
     }
 
-    override fun setThumb(thumb: Drawable) {
+    override fun setThumb(thumb: Drawable?) {
         mThumb = thumb
         super.setThumb(thumb)
     }


### PR DESCRIPTION
[crash.log](https://github.com/gedoor/legado/files/9098534/crash.log)
根据[官方文档](https://developer.android.com/reference/kotlin/android/widget/AbsSeekBar#setthumb)的参数描述，该函数传入的参数有可能为null