### PR TITLE
优化分组搜索

### DIFF
--- a/app/src/main/java/io/legado/app/data/dao/BookSourceDao.kt
+++ b/app/src/main/java/io/legado/app/data/dao/BookSourceDao.kt
@@ -96,7 +96,14 @@ interface BookSourceDao {
     @Query("select * from book_sources where bookSourceGroup like '%' || :group || '%'")
     fun getByGroup(group: String): List<BookSource>
 
-    @Query("select * from book_sources where enabled = 1 and bookSourceGroup like '%' || :group || '%'")
+    @Query(
+        """select * from book_sources 
+        where enabled = 1 
+        and (bookSourceGroup = :group
+            or bookSourceGroup like :group || ',%' 
+            or bookSourceGroup like  '%,' || :group
+            or bookSourceGroup like  '%,' || :group || ',%')"""
+    )
     fun getEnabledByGroup(group: String): List<BookSource>
 
     @Query("select * from book_sources where enabled = 1 and bookSourceType = :type")

--- a/app/src/main/java/io/legado/app/ui/book/search/SearchAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/search/SearchAdapter.kt
@@ -69,7 +69,7 @@ class SearchAdapter(context: Context, val callBack: CallBack) :
     override fun registerListener(holder: ItemViewHolder, binding: ItemSearchBinding) {
         binding.root.setOnClickListener {
             getItem(holder.layoutPosition)?.let {
-                callBack.showBookInfo(it.name, it.author)
+                callBack.showBookInfo(it.name, it.author, it.bookUrl)
             }
         }
     }
@@ -128,6 +128,6 @@ class SearchAdapter(context: Context, val callBack: CallBack) :
     }
 
     interface CallBack {
-        fun showBookInfo(name: String, author: String)
+        fun showBookInfo(name: String, author: String, bookUrl: String)
     }
 }


### PR DESCRIPTION
修复分组搜索可能会搜索到别的分组书源的bug
修复书籍详情页可能会显示别的分组书源的bug
优化无搜索结果时的提示，先提示关闭精准搜索，再提示切换到全部分组