### PR TITLE
disable popup animations when eink mode enabled, fixed #1398 | 解决部分墨水屏设备上按钮无效的问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadMenu.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadMenu.kt
@@ -247,16 +247,22 @@ class ReadMenu @JvmOverloads constructor(
 
         //搜索
         fabSearch.setOnClickListener {
-            runMenuOut {
+            if(AppConfig.isEInkMode)
                 callBack.openSearchActivity(null)
-            }
+            else
+                runMenuOut {
+                    callBack.openSearchActivity(null)
+                }
         }
 
         //自动翻页
         fabAutoPage.setOnClickListener {
-            runMenuOut {
+            if(AppConfig.isEInkMode)
                 callBack.autoPage()
-            }
+            else
+                runMenuOut {
+                    callBack.autoPage()
+                }
         }
 
         //替换
@@ -276,32 +282,47 @@ class ReadMenu @JvmOverloads constructor(
 
         //目录
         llCatalog.setOnClickListener {
-            runMenuOut {
+            if(AppConfig.isEInkMode)
                 callBack.openChapterList()
-            }
+            else
+                runMenuOut {
+                    callBack.openChapterList()
+                }
         }
 
         //朗读
         llReadAloud.setOnClickListener {
-            runMenuOut {
+            if(AppConfig.isEInkMode)
                 callBack.onClickReadAloud()
-            }
+            else
+                runMenuOut {
+                    callBack.onClickReadAloud()
+                }
         }
         llReadAloud.onLongClick {
-            runMenuOut { callBack.showReadAloudDialog() }
+            if(AppConfig.isEInkMode)
+                callBack.showReadAloudDialog()
+            else
+                runMenuOut { callBack.showReadAloudDialog() }
         }
         //界面
         llFont.setOnClickListener {
-            runMenuOut {
+            if(AppConfig.isEInkMode)
                 callBack.showReadStyle()
-            }
+            else
+                runMenuOut {
+                    callBack.showReadStyle()
+                }
         }
 
         //设置
         llSetting.setOnClickListener {
-            runMenuOut {
+            if(AppConfig.isEInkMode)
                 callBack.showMoreSetting()
-            }
+            else
+                runMenuOut {
+                    callBack.showMoreSetting()
+                }
         }
     }
 


### PR DESCRIPTION
修复了一个古老的issue， 在dptrp等墨水屏机型上动画会导致按钮无反应的bug（详见 #1398，最新版本legado已复现）
通过检测是否为墨水屏模式禁用相应按钮的动画可以解决这一问题