### PR TITLE
feat: decode decrypted image bytes

### DIFF
--- a/app/src/main/assets/help/jsHelp.md
+++ b/app/src/main/assets/help/jsHelp.md
@@ -55,15 +55,14 @@ java.getElements(ruleStr: String)
 java.reGetBook()
 java.refreshTocUrl()
 ```
-
-### [js扩展类](https://github.com/gedoor/legado/blob/master/app/src/main/java/io/legado/app/help/JsExtensions.kt) 部分函数
-
 * 变量存取
 
 ```
 java.get(key)
 java.put(key, value)
 ```
+
+### [js扩展类](https://github.com/gedoor/legado/blob/master/app/src/main/java/io/legado/app/help/JsExtensions.kt) 部分函数
 
 * 网络请求
 

--- a/app/src/main/assets/help/ruleHelp.md
+++ b/app/src/main/assets/help/ruleHelp.md
@@ -153,3 +153,7 @@ let options = {
 
 * 购买操作
 > 可直接填写链接或者JavaScript，如果执行结果是字符串链接将会自动打开浏览器
+
+* 图片解密
+> 适用于图片需要二次解密的情况，直接填写JavaScript，返回解密后的bytes
+> 部分变量说明：java（仅支持[js扩展类](https://github.com/gedoor/legado/blob/master/app/src/main/java/io/legado/app/help/JsExtensions.kt)），result为待解密图片的bytes，src为图片链接

--- a/app/src/main/java/io/legado/app/data/entities/rule/ContentRule.kt
+++ b/app/src/main/java/io/legado/app/data/entities/rule/ContentRule.kt
@@ -11,5 +11,6 @@ data class ContentRule(
     var sourceRegex: String? = null,
     var replaceRegex: String? = null, //替换规则
     var imageStyle: String? = null,   //默认大小居中,FULL最大宽度
+    var imageDecode: String? = null, //图片bytes二次解密js, 返回解密后的bytes
     var payAction: String? = null,    //购买操作,js或者包含{{js}}的url
 ) : Parcelable

--- a/app/src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditActivity.kt
@@ -297,6 +297,7 @@ class BookSourceEditActivity :
             add(EditEntity("sourceRegex", cr?.sourceRegex, R.string.rule_source_regex))
             add(EditEntity("replaceRegex", cr?.replaceRegex, R.string.rule_replace_regex))
             add(EditEntity("imageStyle", cr?.imageStyle, R.string.rule_image_style))
+            add(EditEntity("imageDecode", cr?.imageDecode, R.string.rule_image_decode))
             add(EditEntity("payAction", cr?.payAction, R.string.rule_pay_action))
         }
         // 段评
@@ -451,6 +452,7 @@ class BookSourceEditActivity :
                 "sourceRegex" -> contentRule.sourceRegex = it.value
                 "replaceRegex" -> contentRule.replaceRegex = it.value
                 "imageStyle" -> contentRule.imageStyle = it.value
+                "imageDecode" -> contentRule.imageDecode = it.value
                 "payAction" -> contentRule.payAction = it.value
             }
         }

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1025,4 +1025,5 @@
     <string name="tag_explore_disabled">标志:发现已禁用</string>
     <string name="show_read_title_addition">show read title addition area</string>
     <string name="read_bar_style_follow_page">read bar style follow page</string>
+    <string name="rule_image_decode">Decode Image(imageDecode)</string>
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -1028,4 +1028,5 @@
     <string name="tag_explore_disabled">标志:发现已禁用</string>
     <string name="show_read_title_addition">show read title addition area</string>
     <string name="read_bar_style_follow_page">read bar style follow page</string>
+    <string name="rule_image_decode">Decode Image(imageDecode)</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1028,4 +1028,5 @@
     <string name="tag_explore_disabled">标志:发现已禁用</string>
     <string name="show_read_title_addition">show read title addition area</string>
     <string name="read_bar_style_follow_page">read bar style follow page</string>
+    <string name="rule_image_decode">Decode Image(imageDecode)</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1025,4 +1025,5 @@
     <string name="tag_explore_disabled">标志:发现已禁用</string>
     <string name="show_read_title_addition">展示顶部工具栏附加区域</string>
     <string name="read_bar_style_follow_page">工具栏样式跟随页面</string>
+    <string name="rule_image_decode">图片解密（imageDecode）</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1027,4 +1027,5 @@
     <string name="tag_explore_disabled">标志:发现已禁用</string>
     <string name="show_read_title_addition">展示顶部工具栏附加区域</string>
     <string name="read_bar_style_follow_page">工具栏样式跟随页面</string>
+    <string name="rule_image_decode">图片解密（imageDecode）</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1027,4 +1027,5 @@
     <string name="tag_explore_disabled">标志:发现已禁用</string>
     <string name="show_read_title_addition">展示顶部工具栏附加区域</string>
     <string name="read_bar_style_follow_page">工具栏样式跟随页面</string>
+    <string name="rule_image_decode">图片解密（imageDecode）</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1028,4 +1028,5 @@
     <string name="tag_explore_disabled">标志:发现已禁用</string>
     <string name="show_read_title_addition">show read title addition area</string>
     <string name="read_bar_style_follow_page">read bar style follow page</string>
+    <string name="rule_image_decode">Decode Image(imageDecode)</string>
 </resources>


### PR DESCRIPTION
某些漫画网站的图片需要在客户端进行二次解密才能正常观看

加密数据  -> 加密后的图片链接 -> 下载并解密


目前对于这种情况只能写在正文规则里，手动java.ajax(..type..)下载图片并解密，使得书源调试卡在下载环节，还会触发网站并发限制
