### PR TITLE
fix: 全文搜索某些情况无法搜索到标题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
@@ -85,10 +85,7 @@ class ReadBookViewModel(application: Application) : BaseViewModel(application) {
         } else if (isSameBook) {
             if (ReadBook.curTextChapter != null) {
                 ReadBook.callBack?.upContent(resetPageOffset = false)
-            } else if(ReadBook.durChapterIndex == book.durChapterIndex) {
-                ReadBook.loadContent(resetPageOffset = true)
             } else {
-                ReadBook.durChapterIndex = book.durChapterIndex
                 ReadBook.loadContent(resetPageOffset = true)
             }
         } else {

--- a/app/src/main/java/io/legado/app/ui/book/searchContent/SearchContentViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/searchContent/SearchContentViewModel.kt
@@ -23,7 +23,6 @@ class SearchContentViewModel(application: Application) : BaseViewModel(applicati
     var searchResultCounts = 0
     val cacheChapterNames = hashSetOf<String>()
     val searchResultList: MutableList<SearchResult> = mutableListOf()
-    var mContent: String = ""
 
     fun initBook(bookUrl: String, success: () -> Unit) {
         this.bookUrl = bookUrl
@@ -45,9 +44,9 @@ class SearchContentViewModel(application: Application) : BaseViewModel(applicati
         if (chapter != null) {
             book?.let { book ->
                 val chapterContent = BookHelp.getContent(book, chapter)
+                val mContent: String
                 coroutineContext.ensureActive()
                 if (chapterContent != null) {
-                    //先搜索没有启用净化的正文
                     withContext(Dispatchers.IO) {
                         chapter.title = when (AppConfig.chineseConverterType) {
                             1 -> ChineseUtils.t2s(chapter.title)
@@ -56,13 +55,10 @@ class SearchContentViewModel(application: Application) : BaseViewModel(applicati
                         }
                         coroutineContext.ensureActive()
                         mContent = contentProcessor!!.getContent(
-                            book, chapter, chapterContent,
-                            chineseConvert = true,
-                            reSegment = false,
-                            useReplace = false
+                            book, chapter, chapterContent
                         ).joinToString("")
                     }
-                    val positions = searchPosition(query)
+                    val positions = searchPosition(mContent, query)
                     positions.forEachIndexed { index, position ->
                         coroutineContext.ensureActive()
                         val construct = getResultAndQueryIndex(mContent, position, query)
@@ -84,20 +80,13 @@ class SearchContentViewModel(application: Application) : BaseViewModel(applicati
         return searchResultsWithinChapter
     }
 
-    private suspend fun searchPosition(pattern: String): List<Int> {
+    private suspend fun searchPosition(content: String, pattern: String): List<Int> {
         val position: MutableList<Int> = mutableListOf()
-        var index = mContent.indexOf(pattern)
-        if (index >= 0) {
-            //搜索到内容允许净化
-            if (book!!.getUseReplaceRule()) {
-                mContent = contentProcessor!!.replaceContent(mContent)
-                index = mContent.indexOf(pattern)
-            }
-            while (index >= 0) {
-                coroutineContext.ensureActive()
-                position.add(index)
-                index = mContent.indexOf(pattern, index + pattern.length)
-            }
+        var index = content.indexOf(pattern)
+        while (index >= 0) {
+            coroutineContext.ensureActive()
+            position.add(index)
+            index = content.indexOf(pattern, index + pattern.length)
         }
         return position
     }


### PR DESCRIPTION
- 正文净化规则中有净化标题的规则情况下 无法搜索到标题的bug
- 书籍启用`分段`功能，无法准确定位搜索结果

