### PR TITLE
Cronet 支持DnsHttpsSvcb

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ def version = "3." + releaseTime()
 def gitCommits = Integer.parseInt('git rev-list HEAD --count'.execute().text.trim())
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     buildToolsVersion "33.0.0"
     namespace 'io.legado.app'
     kotlinOptions {
@@ -47,6 +47,8 @@ android {
         project.ext.set("archivesBaseName", name + "_" + version)
         multiDexEnabled true
 
+        buildConfigField "String", "Cronet_Version", "\"$CronetVersion\""
+
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments += [
@@ -63,7 +65,6 @@ android {
     }
     buildTypes {
         release {
-            buildConfigField "String", "Cronet_Version", "\"$CronetVersion\""
             if (project.hasProperty("RELEASE_STORE_FILE")) {
                 signingConfig signingConfigs.myConfig
             }
@@ -73,7 +74,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         debug {
-            buildConfigField "String", "Cronet_Version", "\"$CronetVersion\""
+
             if (project.hasProperty("RELEASE_STORE_FILE")) {
                 signingConfig signingConfigs.myConfig
             }
@@ -82,13 +83,15 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
-        android.applicationVariants.all { variant ->
-            variant.outputs.all {
-                def flavor = variant.productFlavors[0].name
-                outputFileName = "${name}_${flavor}_${defaultConfig.versionName}.apk"
-            }
+    }
+
+    android.applicationVariants.all { variant ->
+        variant.outputs.all {
+            def flavor = variant.productFlavors[0].name
+            outputFileName = "${name}_${flavor}_${defaultConfig.versionName}.apk"
         }
     }
+
     flavorDimensions "mode"
     productFlavors {
         app {
@@ -125,6 +128,7 @@ android {
 }
 
 dependencies {
+    compileOnly "com.android.tools.build:gradle:$agp_version"
     //noinspection GradleDependency,GradlePackageUpdate
     coreLibraryDesugaring('com.android.tools:desugar_jdk_libs:1.2.2')
     testImplementation('junit:junit:4.13.2')

--- a/app/src/main/java/io/legado/app/help/http/cronet/CronetHelper.kt
+++ b/app/src/main/java/io/legado/app/help/http/cronet/CronetHelper.kt
@@ -12,6 +12,7 @@ import org.chromium.net.CronetEngine.Builder.HTTP_CACHE_DISK
 import org.chromium.net.ExperimentalCronetEngine
 import org.chromium.net.UploadDataProviders
 import org.chromium.net.UrlRequest
+import org.json.JSONObject
 import splitties.init.appCtx
 
 
@@ -29,6 +30,7 @@ val cronetEngine: ExperimentalCronetEngine? by lazy {
         enableHttp2(true)  //设置支持http/2
         enablePublicKeyPinningBypassForLocalTrustAnchors(true)
         enableBrotli(true)//Brotli压缩
+        setExperimentalOptions(options)
     }
     try {
         val engine = builder.build()
@@ -38,6 +40,28 @@ val cronetEngine: ExperimentalCronetEngine? by lazy {
         AppLog.put("初始化cronetEngine出错", e)
         return@lazy null
     }
+}
+
+val options by lazy {
+    val options = JSONObject()
+
+    //设置域名映射规则
+    //MAP hostname ip,MAP hostname ip
+//    val host = JSONObject()
+//    host.put("host_resolver_rules","")
+//    options.put("HostResolverRules", host)
+
+    //启用DnsHttpsSvcb更容易迁移到http3
+    val dnsSvcb = JSONObject()
+    dnsSvcb.put("enable", true)
+    dnsSvcb.put("enable_insecure", true)
+    dnsSvcb.put("use_alpn", true)
+    options.put("UseDnsHttpsSvcb", dnsSvcb)
+
+    options.put("AsyncDNS", JSONObject("{'enable':true}"))
+
+
+    options.toString()
 }
 
 fun buildRequest(request: Request, callback: UrlRequest.Callback): UrlRequest? {

--- a/epublib/build.gradle
+++ b/epublib/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
-    buildToolsVersion '32.0.0'
+    compileSdk 33
+    //buildToolsVersion '32.0.0'
     namespace 'me.ag2s.epublib'
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 32
+        minSdk 21
+        targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -18,8 +18,6 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-        }
-        android {
         }
 
     }
@@ -33,5 +31,6 @@ android {
 }
 
 dependencies {
+    compileOnly "com.android.tools.build:gradle:$agp_version"
     implementation "androidx.annotation:annotation:1.5.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+kotlin.incremental.useClasspathSnapshot=true
 android.enableResourceOptimizations=true
 android.enableNewResourceShrinker=true
 android.experimental.enableNewResourceShrinker.preciseShrinking=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 23 22:07:39 CST 2022
+#Mon Sep 26 08:03:55 CST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Cronet 设置`UseDnsHttpsSvcb`等实验选项支持HTTPS 类型的dns请求，从dns HTTPS记录中就能获取到支持的alpn,用来加快升级http3。

https://github.com/chromium/chromium/commit/77379815db4354afa3a81c9dd26995c7edc76b16