### PR TITLE
修复自动转换Base64 Hex导致的解密失败

### DIFF
--- a/app/src/main/assets/help/jsHelp.md
+++ b/app/src/main/assets/help/jsHelp.md
@@ -162,14 +162,19 @@ deleteFile(path: String)
 > DES transformation默认实现DES/ECB/PKCS5Padding  
 > TripleDES tansformation默认实现DESede/ECB/PKCS5Padding  
 > 内部实现为cn.hutool.crypto 解密加密接口支持ByteArray|Base64String|HexString|InputStream  
-> 输入参数key iv 支持ByteArray|Base64String|HexString|Utf8String
+> 输入参数key iv 支持ByteArray|Utf8String  
+> 如果key iv 为Hex Base64,且需要解码为ByteArray，调用java.decodeBase64Hex
 ```
 //解密为ByteArray 字符串
 java.createSymmetricCrypto(transformation, key, iv).decrypt(data)
+
 java.createSymmetricCrypto(transformation, key, iv).decryptStr(data)
+
 //加密为ByteArray Base64字符 HEX字符
 java.createSymmetricCrypto(transformation, key, iv).encrypt(data)
+
 java.createSymmetricCrypto(transformation, key, iv).encryptBase64(data)
+
 java.createSymmetricCrypto(transformation, key, iv).encryptHex(data)
 ```
 * 摘要

--- a/app/src/main/java/io/legado/app/constant/AppPattern.kt
+++ b/app/src/main/java/io/legado/app/constant/AppPattern.kt
@@ -13,8 +13,6 @@ object AppPattern {
 
     //dataURL图片类型
     val dataUriRegex = Regex("data:.*?;base64,(.*)")
-    //Base64字符串
-    val base64Regex = Regex("^[a-zA-Z0-9\\+\\/=]+$")
 
     val nameRegex = Regex("\\s+作\\s*者.*|\\s+\\S+\\s+著")
     val authorRegex = Regex("^\\s*作\\s*者[:：\\s]+|\\s+著")

--- a/app/src/main/java/io/legado/app/help/JsExtensions.kt
+++ b/app/src/main/java/io/legado/app/help/JsExtensions.kt
@@ -7,6 +7,7 @@ import cn.hutool.crypto.digest.DigestUtil
 import cn.hutool.crypto.digest.HMac
 import cn.hutool.core.util.HexUtil
 import cn.hutool.crypto.symmetric.SymmetricCrypto
+import cn.hutool.crypto.SecureUtil
 import io.legado.app.constant.AppConst
 import io.legado.app.constant.AppConst.dateFormat
 import io.legado.app.constant.AppLog
@@ -658,9 +659,32 @@ interface JsExtensions {
      * java.createSymmetricCrypto(transformation, key, iv).encrypt(data)
      * java.createSymmetricCrypto(transformation, key, iv).encryptBase64(data)
      * java.createSymmetricCrypto(transformation, key, iv).encryptHex(data)
-    */
 
-    /* 自动转换key iv 到ByteArray 支持base64 hex uft8*/
+     * 如果key iv 为Hex Base64,且需要解码为ByteArray，调用java.decodeBase64Hex
+
+    */
+    /* iv key 为Base64String HexString 到ByteArray的转换函数 */
+    fun decodeBase64Hex(str: String): ByteArray? {
+        return SecureUtil.decode(str)
+    }
+
+    /* 调用SymmetricCrypto key为null时使用随机密钥*/
+    fun createSymmetricCrypto(
+        transformation: String,
+        key: ByteArray?,
+        iv: ByteArray?
+    ): SymmetricCrypto {
+        val symmetricCrypto = SymmetricCrypto(transformation, key)
+        return if (iv != null && !iv.isEmpty()) symmetricCrypto.setIv(iv) else symmetricCrypto
+    }
+
+    fun createSymmetricCrypto(
+        transformation: String,
+        key: ByteArray
+    ): SymmetricCrypto {
+        return createSymmetricCrypto(transformation, key, null)
+    }
+
     fun createSymmetricCrypto(
         transformation: String,
         key: String
@@ -674,34 +698,10 @@ interface JsExtensions {
         iv: String?
     ): SymmetricCrypto {
         return createSymmetricCrypto(
-            transformation,
-            StringUtils.encodeStringToByteArray(key),
-            StringUtils.encodeStringToByteArray(iv)
+            transformation, key.encodeToByteArray(), iv?.encodeToByteArray()
         )
     }
 
-    /* 调用SymmetricCrypto key为null时使用随机密钥*/
-    fun createSymmetricCrypto(
-        transformation: String
-    ): SymmetricCrypto {
-        return createSymmetricCrypto(transformation, null, null)
-    }
-
-    fun createSymmetricCrypto(
-        transformation: String,
-        key: ByteArray
-    ): SymmetricCrypto {
-        return createSymmetricCrypto(transformation, key, null)
-    }
-
-    fun createSymmetricCrypto(
-        transformation: String,
-        key: ByteArray?,
-        iv: ByteArray?
-    ): SymmetricCrypto {
-        val symmetricCrypto = SymmetricCrypto(transformation, key)
-        return if (iv != null && !iv.isEmpty()) symmetricCrypto.setIv(iv) else symmetricCrypto
-    }
 
 //******************消息摘要/散列消息鉴别码************************//
 

--- a/app/src/main/java/io/legado/app/utils/StringExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/StringExtensions.kt
@@ -8,7 +8,6 @@ import android.net.Uri
 import android.text.Editable
 import cn.hutool.core.lang.Validator
 import io.legado.app.constant.AppPattern.dataUriRegex
-import io.legado.app.constant.AppPattern.base64Regex
 import java.io.File
 import java.util.*
 
@@ -37,11 +36,6 @@ fun String?.isAbsUrl() =
 fun String?.isDataUrl() =
     this?.let {
         dataUriRegex.matches(it)
-    } ?: false
-
-fun String?.isBase64() =
-    this?.let {
-        base64Regex.matches(it)
     } ?: false
 
 fun String?.isJson(): Boolean =

--- a/app/src/main/java/io/legado/app/utils/StringUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/StringUtils.kt
@@ -1,11 +1,7 @@
 package io.legado.app.utils
 
-import android.util.Base64
 import android.annotation.SuppressLint
 import android.text.TextUtils.isEmpty
-
-import cn.hutool.core.util.HexUtil
-import cn.hutool.core.lang.Validator
 
 import java.text.DecimalFormat
 import java.text.SimpleDateFormat
@@ -289,18 +285,6 @@ object StringUtils {
         }
         m.appendTail(buf)
         return buf.toString()
-    }
-
-    /**
-     * 自动识别Base64 Hex Utf8字符串 并转成ByteArray
-     */
-    fun encodeStringToByteArray(str: String?): ByteArray? {
-        return when {
-            str.isNullOrBlank() -> null
-            Validator.isHex(str) -> HexUtil.decodeHex(str)
-            str.isBase64() -> Base64.decode(str, Base64.DEFAULT)
-            else -> str.encodeToByteArray()
-        }
     }
 
 }


### PR DESCRIPTION
有的解密函数中key iv 为base64'字符串，不需要解码为byteArray

需要解码时调用java.decodeBase64Hex
	
