### PR TITLE
让安装了GMS的低版本Android在okhttp模式时支持TLSv1.3

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/manage/ComposeView.kt
+++ b/app/src/main/java/io/legado/app/ui/book/manage/ComposeView.kt
@@ -26,7 +26,7 @@ fun BatchChangeSourceDialog(
                     cancel.invoke()
                     state.value = false
                 }, content = {
-                    Text(text = "取消")
+                    Text(text = appCtx.getString(R.string.cancel))
                 })
             },
             title = {


### PR DESCRIPTION
https://f-droid.org/zh_Hans/2020/05/29/android-updates-and-tls-connections.html

https://developer.android.google.cn/reference/javax/net/ssl/SSLSocket