### PR TITLE
修复从书籍详情目录页进入指定章节时自动跳转到同步章节

### DIFF
--- a/app/src/main/java/io/legado/app/model/ReadBook.kt
+++ b/app/src/main/java/io/legado/app/model/ReadBook.kt
@@ -35,6 +35,7 @@ object ReadBook : CoroutineScope by MainScope() {
     var durChapterIndex = 0
     var durChapterPos = 0
     var isLocalBook = true
+    var chapterChanged = false
     var prevTextChapter: TextChapter? = null
     var curTextChapter: TextChapter? = null
     var nextTextChapter: TextChapter? = null

--- a/app/src/main/java/io/legado/app/ui/book/info/BookInfoActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/info/BookInfoActivity.kt
@@ -66,6 +66,7 @@ class BookInfoActivity :
                     withContext(IO) {
                         book.durChapterIndex = it.first
                         book.durChapterPos = it.second
+                        chapterChanged = it.third
                         appDb.bookDao.update(book)
                     }
                     viewModel.chapterListData.value?.let { chapterList ->
@@ -103,6 +104,7 @@ class BookInfoActivity :
         }
     }
     private var tocChanged = false
+    private var chapterChanged = false
     private val waitDialog by lazy { WaitDialog(this) }
     private var editMenuItem: MenuItem? = null
 
@@ -620,6 +622,7 @@ class BookInfoActivity :
                     .putExtra("bookUrl", book.bookUrl)
                     .putExtra("inBookshelf", viewModel.inBookshelf)
                     .putExtra("tocChanged", tocChanged)
+                    .putExtra("chapterChanged", chapterChanged)
             )
         }
         tocChanged = false

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
@@ -60,6 +60,7 @@ class ReadBookViewModel(application: Application) : BaseViewModel(application) {
         execute {
             ReadBook.inBookshelf = intent.getBooleanExtra("inBookshelf", true)
             ReadBook.tocChanged = intent.getBooleanExtra("tocChanged", false)
+            ReadBook.chapterChanged = intent.getBooleanExtra("chapterChanged", false)
             val bookUrl = intent.getStringExtra("bookUrl")
             val book = when {
                 bookUrl.isNullOrEmpty() -> appDb.bookDao.lastReadBook
@@ -104,7 +105,10 @@ class ReadBookViewModel(application: Application) : BaseViewModel(application) {
             }
             ReadBook.loadContent(resetPageOffset = false)
         }
-        if (!isSameBook || !BaseReadAloudService.isRun) {
+        if (ReadBook.chapterChanged) {
+            // 有章节跳转不同步阅读进度
+            ReadBook.chapterChanged = false
+        } else if (!isSameBook || !BaseReadAloudService.isRun) {
             syncBookProgress(book)
         }
         if (!book.isLocal && ReadBook.bookSource == null) {

--- a/app/src/main/java/io/legado/app/ui/book/toc/ChapterListFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/ChapterListFragment.kt
@@ -162,7 +162,10 @@ class ChapterListFragment : VMBaseFragment<TocViewModel>(R.layout.fragment_chapt
 
     override fun openChapter(bookChapter: BookChapter) {
         activity?.run {
-            setResult(RESULT_OK, Intent().putExtra("index", bookChapter.index))
+            setResult(RESULT_OK, Intent()
+                .putExtra("index", bookChapter.index)
+                .putExtra("chapterChanged", bookChapter.index != durChapterIndex)
+            )
             finish()
         }
     }

--- a/app/src/main/java/io/legado/app/ui/book/toc/TocActivityResult.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/TocActivityResult.kt
@@ -5,19 +5,20 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 
-class TocActivityResult : ActivityResultContract<String, Pair<Int, Int>?>() {
+class TocActivityResult : ActivityResultContract<String, Triple<Int, Int, Boolean>?>() {
 
     override fun createIntent(context: Context, input: String): Intent {
         return Intent(context, TocActivity::class.java)
             .putExtra("bookUrl", input)
     }
 
-    override fun parseResult(resultCode: Int, intent: Intent?): Pair<Int, Int>? {
+    override fun parseResult(resultCode: Int, intent: Intent?): Triple<Int, Int, Boolean>? {
         if (resultCode == RESULT_OK) {
             intent?.let {
-                return Pair(
+                return Triple(
                     it.getIntExtra("index", 0),
-                    it.getIntExtra("chapterPos", 0)
+                    it.getIntExtra("chapterPos", 0),
+                    it.getBooleanExtra("chapterChanged", false)
                 )
             }
         }


### PR DESCRIPTION
从目录页进入不同章节时，不应该自动同步

bug:

https://user-images.githubusercontent.com/22561041/231321195-77d7c29d-121b-42a4-a15d-6e631787a421.mp4

fix:

https://user-images.githubusercontent.com/22561041/231321216-6ab7dddb-0079-49b6-80bd-667e14bdd3a3.mp4

