### PR TITLE
折叠换源分组菜单; 修复自动换组UI不更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules/
 /app/google
 /app/gradle.properties
 package-lock.json
+.idea/*
+

--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceDialog.kt
@@ -32,7 +32,14 @@ import io.legado.app.ui.book.source.edit.BookSourceEditActivity
 import io.legado.app.ui.book.source.manage.BookSourceActivity
 import io.legado.app.ui.widget.dialog.WaitDialog
 import io.legado.app.ui.widget.recycler.VerticalDivider
-import io.legado.app.utils.*
+import io.legado.app.utils.StartActivityContract
+import io.legado.app.utils.applyTint
+import io.legado.app.utils.cnCompare
+import io.legado.app.utils.dpToPx
+import io.legado.app.utils.observeEvent
+import io.legado.app.utils.setLayout
+import io.legado.app.utils.startActivity
+import io.legado.app.utils.toastOnUi
 import io.legado.app.utils.viewbindingdelegate.viewBinding
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.conflate
@@ -72,6 +79,7 @@ class ChangeBookSourceDialog() : BaseDialogFragment(R.layout.dialog_book_change_
                         cancelButton()
                         okButton {
                             AppConfig.searchGroup = ""
+                            upGroupMenu()
                             viewModel.startSearch()
                         }
                     }
@@ -233,17 +241,15 @@ class ChangeBookSourceDialog() : BaseDialogFragment(R.layout.dialog_book_change_
             R.id.menu_start_stop -> viewModel.startOrStopSearch()
             R.id.menu_source_manage -> startActivity<BookSourceActivity>()
             R.id.menu_refresh_list -> viewModel.startRefreshList()
-            else -> if (item?.groupId == R.id.source_group) {
-                if (!item.isChecked) {
-                    item.isChecked = true
-                    if (item.title.toString() == getString(R.string.all_source)) {
-                        AppConfig.searchGroup = ""
-                    } else {
-                        AppConfig.searchGroup = item.title.toString()
-                    }
-                    viewModel.startOrStopSearch()
-                    viewModel.refresh()
+            else -> if (item?.groupId == R.id.source_group && !item.isChecked) {
+                item.isChecked = true
+                if (item.title.toString() == getString(R.string.all_source)) {
+                    AppConfig.searchGroup = ""
+                } else {
+                    AppConfig.searchGroup = item.title.toString()
                 }
+                viewModel.startOrStopSearch()
+                viewModel.refresh()
             }
         }
         return false
@@ -339,24 +345,25 @@ class ChangeBookSourceDialog() : BaseDialogFragment(R.layout.dialog_book_change_
      * 更新分组菜单
      */
     private fun upGroupMenu() {
-        val menu: Menu = binding.toolBar.menu
-        val selectedGroup = AppConfig.searchGroup
-        menu.removeGroup(R.id.source_group)
-        val allItem = menu.add(R.id.source_group, Menu.NONE, Menu.NONE, R.string.all_source)
-        var hasSelectedGroup = false
-        groups.sortedWith { o1, o2 ->
-            o1.cnCompare(o2)
-        }.forEach { group ->
-            menu.add(R.id.source_group, Menu.NONE, Menu.NONE, group)?.let {
-                if (group == selectedGroup) {
-                    it.isChecked = true
-                    hasSelectedGroup = true
+        binding.toolBar.menu.findItem(R.id.menu_group)?.subMenu?.let { menu ->
+            val selectedGroup = AppConfig.searchGroup
+            menu.removeGroup(R.id.source_group)
+            val allItem = menu.add(R.id.source_group, Menu.NONE, Menu.NONE, R.string.all_source)
+            var hasSelectedGroup = false
+            groups.sortedWith { o1, o2 ->
+                o1.cnCompare(o2)
+            }.forEach { group ->
+                menu.add(R.id.source_group, Menu.NONE, Menu.NONE, group)?.let {
+                    if (group == selectedGroup) {
+                        it.isChecked = true
+                        hasSelectedGroup = true
+                    }
                 }
             }
-        }
-        menu.setGroupCheckable(R.id.source_group, true, true)
-        if (!hasSelectedGroup) {
-            allItem.isChecked = true
+            menu.setGroupCheckable(R.id.source_group, true, true)
+            if (!hasSelectedGroup) {
+                allItem.isChecked = true
+            }
         }
     }
 

--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeChapterSourceDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeChapterSourceDialog.kt
@@ -97,6 +97,7 @@ class ChangeChapterSourceDialog() : BaseDialogFragment(R.layout.dialog_chapter_c
                         noButton()
                         yesButton {
                             AppConfig.searchGroup = ""
+                            upGroupMenu()
                             viewModel.startSearch()
                         }
                     }
@@ -262,17 +263,15 @@ class ChangeChapterSourceDialog() : BaseDialogFragment(R.layout.dialog_chapter_c
             }
             R.id.menu_start_stop -> viewModel.startOrStopSearch()
             R.id.menu_source_manage -> startActivity<BookSourceActivity>()
-            else -> if (item?.groupId == R.id.source_group) {
-                if (!item.isChecked) {
-                    item.isChecked = true
-                    if (item.title.toString() == getString(R.string.all_source)) {
-                        AppConfig.searchGroup = ""
-                    } else {
-                        AppConfig.searchGroup = item.title.toString()
-                    }
-                    viewModel.startOrStopSearch()
-                    viewModel.refresh()
+            else -> if (item?.groupId == R.id.source_group && !item.isChecked) {
+                item.isChecked = true
+                if (item.title.toString() == getString(R.string.all_source)) {
+                    AppConfig.searchGroup = ""
+                } else {
+                    AppConfig.searchGroup = item.title.toString()
                 }
+                viewModel.startOrStopSearch()
+                viewModel.refresh()
             }
         }
         return false
@@ -359,24 +358,25 @@ class ChangeChapterSourceDialog() : BaseDialogFragment(R.layout.dialog_chapter_c
      * 更新分组菜单
      */
     private fun upGroupMenu() {
-        val menu: Menu = binding.toolBar.menu
-        val selectedGroup = AppConfig.searchGroup
-        menu.removeGroup(R.id.source_group)
-        val allItem = menu.add(R.id.source_group, Menu.NONE, Menu.NONE, R.string.all_source)
-        var hasSelectedGroup = false
-        groups.sortedWith { o1, o2 ->
-            o1.cnCompare(o2)
-        }.forEach { group ->
-            menu.add(R.id.source_group, Menu.NONE, Menu.NONE, group)?.let {
-                if (group == selectedGroup) {
-                    it.isChecked = true
-                    hasSelectedGroup = true
+        binding.toolBar.menu.findItem(R.id.menu_group)?.subMenu?.let { menu ->
+            val selectedGroup = AppConfig.searchGroup
+            menu.removeGroup(R.id.source_group)
+            val allItem = menu.add(R.id.source_group, Menu.NONE, Menu.NONE, R.string.all_source)
+            var hasSelectedGroup = false
+            groups.sortedWith { o1, o2 ->
+                o1.cnCompare(o2)
+            }.forEach { group ->
+                menu.add(R.id.source_group, Menu.NONE, Menu.NONE, group)?.let {
+                    if (group == selectedGroup) {
+                        it.isChecked = true
+                        hasSelectedGroup = true
+                    }
                 }
             }
-        }
-        menu.setGroupCheckable(R.id.source_group, true, true)
-        if (!hasSelectedGroup) {
-            allItem.isChecked = true
+            menu.setGroupCheckable(R.id.source_group, true, true)
+            if (!hasSelectedGroup) {
+                allItem.isChecked = true
+            }
         }
     }
 

--- a/app/src/main/res/menu/change_source.xml
+++ b/app/src/main/res/menu/change_source.xml
@@ -51,5 +51,17 @@
         android:title="@string/load_toc"
         android:checkable="true"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/menu_group"
+        android:title="@string/group">
 
+        <menu>
+            <group
+                android:id="@+id/source_group"
+                android:checkableBehavior="single">
+            </group>
+
+        </menu>
+
+    </item>
 </menu>


### PR DESCRIPTION
分组一次性只能选择一个，而且换源界面切换分组的几率很低，所以不应该把所有的分组都显示占用空间，应该在需要切换的时候再显示所有的分组。




https://github.com/gedoor/legado/assets/22561041/91504fea-c1c5-4cff-a2e8-89c7859bcea8


