### PR TITLE
换源窗口增加关闭按钮

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceDialog.kt
@@ -241,6 +241,7 @@ class ChangeBookSourceDialog() : BaseDialogFragment(R.layout.dialog_book_change_
 
             R.id.menu_start_stop -> viewModel.startOrStopSearch()
             R.id.menu_source_manage -> startActivity<BookSourceActivity>()
+            R.id.menu_close -> dismissAllowingStateLoss()
             R.id.menu_refresh_list -> viewModel.startRefreshList()
             else -> if (item?.groupId == R.id.source_group && !item.isChecked) {
                 item.isChecked = true

--- a/app/src/main/res/menu/change_source.xml
+++ b/app/src/main/res/menu/change_source.xml
@@ -64,4 +64,9 @@
         </menu>
 
     </item>
+
+    <item
+        android:id="@+id/menu_close"
+        android:title="@string/close"
+        app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
Solve issue #3344 

部分墨水屏设备没有实体返回键，没有虚拟返回键，没有全面屏手势（我的ocean2和这个题主的小米就这样），这时候打开换源窗口就出不去了，简单增加了个close按钮。