### PR TITLE
Fix warp line error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           # not use this output
           # echo "KeyStore=yes" >> $GITHUB_OUTPUT
+          echo -e "\n" >> gradle.properties
           echo RELEASE_KEY_ALIAS='${{ secrets.RELEASE_KEY_ALIAS }}' >> gradle.properties
           echo RELEASE_KEY_PASSWORD='${{ secrets.RELEASE_KEY_PASSWORD }}' >> gradle.properties
           echo RELEASE_STORE_PASSWORD='${{ secrets.RELEASE_STORE_PASSWORD }}' >> gradle.properties


### PR DESCRIPTION
当`gradle.properties`最后一行如下（不是空行）时
``` properties
android.nonFinalResIds=true
```
手动运行action编译版本会错误提示该属性应该是boolean值，
实际写入文件的结果为
``` properties
android.nonFinalResIds=trueRELEASE_KEY_ALIAS='XXX'
```