### PR TITLE
fix: hide book info that is too long

### DIFF
--- a/modules/web/src/components/BookItems.vue
+++ b/modules/web/src/components/BookItems.vue
@@ -104,7 +104,8 @@ const subJustify = computed(() =>
         height: 112px;
         margin-left: 20px;
         flex: 1;
-
+        overflow: hidden;
+        
         .name {
           width: fit-content;
           font-size: 16px;


### PR DESCRIPTION
![{9A7A8276-C1AB-4e40-B7AF-7A9DE1C031C7}](https://github.com/gedoor/legado/assets/36879029/37e93e20-a1d2-42b4-8847-cae77fa23aa2)

Fix too long chapter names.

当书籍章节名称过长时，会溢出并影响书籍列表布局，修复此bug。