### PR TITLE
update 安卓13用系统弹框请求通知权限， 而不是跳转到设置页面手动打开

### DIFF
--- a/app/src/main/java/io/legado/app/service/BaseReadAloudService.kt
+++ b/app/src/main/java/io/legado/app/service/BaseReadAloudService.kt
@@ -562,7 +562,7 @@ abstract class BaseReadAloudService : BaseService(),
             try {
                 val notification = createNotification()
                 if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    Log.d(TAG, "FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK")
+                    //Log.d(TAG, "FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK")
                     startForeground(NotificationId.ReadAloudService, notification.build(),
                         ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
                 }else{

--- a/app/src/main/java/io/legado/app/service/BaseReadAloudService.kt
+++ b/app/src/main/java/io/legado/app/service/BaseReadAloudService.kt
@@ -6,10 +6,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ServiceInfo
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.media.AudioManager
 import android.net.wifi.WifiManager
+import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
 import android.support.v4.media.session.MediaSessionCompat
@@ -567,7 +569,13 @@ abstract class BaseReadAloudService : BaseService(),
         execute {
             try {
                 val notification = createNotification()
-                startForeground(NotificationId.ReadAloudService, notification.build())
+                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    Log.d(TAG, "FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK")
+                    startForeground(NotificationId.ReadAloudService, notification.build(),
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+                }else{
+                    startForeground(NotificationId.ReadAloudService, notification.build())
+                }
             } catch (e: Exception) {
                 AppLog.put("创建朗读通知出错,${e.localizedMessage}", e, true)
                 //创建通知出错不结束服务就会崩溃,服务必须绑定通知

--- a/app/src/main/java/io/legado/app/utils/VersionUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/VersionUtils.kt
@@ -1,0 +1,94 @@
+package io.legado.app.utils
+
+import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
+
+/**
+ * @author Hemanth S (h4h13).
+ */
+
+object VersionUtils {
+    /**
+     * @return true if device is running API >= 23
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.M)
+    fun hasMarshmallow(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+    }
+
+    /**
+     * @return true if device is running API >= 24
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.N)
+    fun hasNougat(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+    }
+
+    /**
+     * @return true if device is running API >= 25
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.N_MR1)
+    fun hasNougatMR(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1
+    }
+
+    /**
+     * @return true if device is running API >= 26
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
+    fun hasOreo(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+    }
+
+    /**
+     * @return true if device is running API >= 27
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O_MR1)
+    fun hasOreoMR1(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
+    }
+
+    /**
+     * @return true if device is running API >= 28
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.P)
+    fun hasP(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+    }
+
+    /**
+     * @return true if device is running API >= 29
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.Q)
+    @JvmStatic
+    fun hasQ(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+    }
+
+    /**
+     * @return true if device is running API >= 30
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.R)
+    @JvmStatic
+    fun hasR(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+    }
+
+    /**
+     * @return true if device is running API >= 31
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.S)
+    @JvmStatic
+    fun hasS(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    }
+
+    /**
+     * @return true if device is running API >= 33
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
+    @JvmStatic
+    fun hasT(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+    }
+}


### PR DESCRIPTION
原来的阅读界面的通知权限判断没有修改，仅增加了进入程序时的申请。
![Snipaste_2024-08-18_06-13-48](https://github.com/user-attachments/assets/b6f878f9-7842-40be-bc72-28771870eb36)
