### PR TITLE
验证流程问题修复

### DIFF
--- a/app/src/main/assets/web/help/md/jsHelp.md
+++ b/app/src/main/assets/web/help/md/jsHelp.md
@@ -20,7 +20,8 @@
 |变量名|调用类|
 |------|-----|
 |java|当前类|
-|baseUrl|当前url,String  |
+|baseUrl|String，当前 url，如 `https://example.com/page/1`|
+|baseUrlWithOptions|String，带参数的当前 url，如 `https://example.com/page/1,{"webView": true}`|
 |result|上一步的结果|
 |book|[书籍类](https://github.com/gedoor/legado/blob/master/app/src/main/java/io/legado/app/data/entities/Book.kt)|
 |chapter|[章节类](https://github.com/gedoor/legado/blob/master/app/src/main/java/io/legado/app/data/entities/BookChapter.kt)|

--- a/app/src/main/java/io/legado/app/help/JsExtensions.kt
+++ b/app/src/main/java/io/legado/app/help/JsExtensions.kt
@@ -226,10 +226,10 @@ interface JsExtensions : JsEncodeUtils {
     /**
      * 使用内置浏览器打开链接，并等待网页结果
      */
-    fun startBrowserAwait(url: String, title: String): StrResponse {
+    fun startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean = true): StrResponse {
         return StrResponse(
             url,
-            SourceVerificationHelp.getVerificationResult(getSource(), url, title, true)
+            SourceVerificationHelp.getVerificationResult(getSource(), url, title, true, refetchAfterSuccess)
         )
     }
 

--- a/app/src/main/java/io/legado/app/help/source/SourceVerificationHelp.kt
+++ b/app/src/main/java/io/legado/app/help/source/SourceVerificationHelp.kt
@@ -30,7 +30,8 @@ object SourceVerificationHelp {
         source: BaseSource?,
         url: String,
         title: String,
-        useBrowser: Boolean
+        useBrowser: Boolean,
+        refetchAfterSuccess: Boolean = true
     ): String {
         source
             ?: throw NoStackTraceException("getVerificationResult parameter source cannot be null")
@@ -45,7 +46,7 @@ object SourceVerificationHelp {
                 IntentData.put(getVerificationResultKey(source), Thread.currentThread())
             }
         } else {
-            startBrowser(source, url, title, true)
+            startBrowser(source, url, title, true, refetchAfterSuccess)
         }
 
         var waitUserInput = false
@@ -72,7 +73,8 @@ object SourceVerificationHelp {
         source: BaseSource?,
         url: String,
         title: String,
-        saveResult: Boolean? = false
+        saveResult: Boolean? = false,
+        refetchAfterSuccess: Boolean? = true
     ) {
         source ?: throw NoStackTraceException("startBrowser parameter source cannot be null")
         appCtx.startActivity<WebViewActivity> {
@@ -81,6 +83,7 @@ object SourceVerificationHelp {
             putExtra("sourceOrigin", source.getKey())
             putExtra("sourceName", source.getTag())
             putExtra("sourceVerificationEnable", saveResult)
+            putExtra("refetchAfterSuccess", refetchAfterSuccess)
             IntentData.put(url, source.getHeaderMap(true))
             IntentData.put(getVerificationResultKey(source), Thread.currentThread())
         }

--- a/app/src/main/java/io/legado/app/help/source/SourceVerificationHelp.kt
+++ b/app/src/main/java/io/legado/app/help/source/SourceVerificationHelp.kt
@@ -19,8 +19,8 @@ object SourceVerificationHelp {
 
     private val waitTime = 1.minutes.inWholeNanoseconds
 
-    private fun getKey(source: BaseSource) = getKey(source.getKey())
-    private fun getKey(sourceKey: String) = "${sourceKey}_verificationResult"
+    private fun getVerificationResultKey(source: BaseSource) = getVerificationResultKey(source.getKey())
+    private fun getVerificationResultKey(sourceKey: String) = "${sourceKey}_verificationResult"
 
     /**
      * 获取书源验证结果
@@ -42,7 +42,7 @@ object SourceVerificationHelp {
                 putExtra("imageUrl", url)
                 putExtra("sourceOrigin", source.getKey())
                 putExtra("sourceName", source.getTag())
-                IntentData.put(getKey(source), Thread.currentThread())
+                IntentData.put(getVerificationResultKey(source), Thread.currentThread())
             }
         } else {
             startBrowser(source, url, title, true)
@@ -75,7 +75,6 @@ object SourceVerificationHelp {
         saveResult: Boolean? = false
     ) {
         source ?: throw NoStackTraceException("startBrowser parameter source cannot be null")
-        val key = getKey(source)
         appCtx.startActivity<WebViewActivity> {
             putExtra("title", title)
             putExtra("url", url)
@@ -83,26 +82,26 @@ object SourceVerificationHelp {
             putExtra("sourceName", source.getTag())
             putExtra("sourceVerificationEnable", saveResult)
             IntentData.put(url, source.getHeaderMap(true))
-            IntentData.put(key, Thread.currentThread())
+            IntentData.put(getVerificationResultKey(source), Thread.currentThread())
         }
     }
 
 
     fun checkResult(sourceKey: String) {
         getResult(sourceKey) ?: setResult(sourceKey, "")
-        val thread = IntentData.get<Thread>(getKey(sourceKey))
+        val thread = IntentData.get<Thread>(getVerificationResultKey(sourceKey))
         LockSupport.unpark(thread)
     }
 
     fun setResult(sourceKey: String, result: String?) {
-        CacheManager.putMemory(getKey(sourceKey), result ?: "")
+        CacheManager.putMemory(getVerificationResultKey(sourceKey), result ?: "")
     }
 
     fun getResult(sourceKey: String): String? {
-        return CacheManager.get(getKey(sourceKey))
+        return CacheManager.get(getVerificationResultKey(sourceKey))
     }
 
     fun clearResult(sourceKey: String) {
-        CacheManager.delete(getKey(sourceKey))
+        CacheManager.delete(getVerificationResultKey(sourceKey))
     }
 }

--- a/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeRule.kt
+++ b/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeRule.kt
@@ -63,10 +63,6 @@ class AnalyzeRule(
     private var analyzeByJSoup: AnalyzeByJSoup? = null
     private var analyzeByJSonPath: AnalyzeByJSonPath? = null
 
-    private var objectChangedXP = false
-    private var objectChangedJS = false
-    private var objectChangedJP = false
-
     private val stringRuleCache = hashMapOf<String, List<SourceRule>>()
 
     private var coroutineContext: CoroutineContext = EmptyCoroutineContext
@@ -80,9 +76,9 @@ class AnalyzeRule(
             else -> content.toString().isJson()
         }
         setBaseUrl(baseUrl)
-        objectChangedXP = true
-        objectChangedJS = true
-        objectChangedJP = true
+        analyzeByXPath = null
+        analyzeByJSoup = null
+        analyzeByJSonPath = null
         return this
     }
 
@@ -114,9 +110,8 @@ class AnalyzeRule(
         return if (o != content) {
             AnalyzeByXPath(o)
         } else {
-            if (analyzeByXPath == null || objectChangedXP) {
+            if (analyzeByXPath == null) {
                 analyzeByXPath = AnalyzeByXPath(content!!)
-                objectChangedXP = false
             }
             analyzeByXPath!!
         }
@@ -129,9 +124,8 @@ class AnalyzeRule(
         return if (o != content) {
             AnalyzeByJSoup(o)
         } else {
-            if (analyzeByJSoup == null || objectChangedJS) {
+            if (analyzeByJSoup == null) {
                 analyzeByJSoup = AnalyzeByJSoup(content!!)
-                objectChangedJS = false
             }
             analyzeByJSoup!!
         }
@@ -144,9 +138,8 @@ class AnalyzeRule(
         return if (o != content) {
             AnalyzeByJSonPath(o)
         } else {
-            if (analyzeByJSonPath == null || objectChangedJP) {
+            if (analyzeByJSonPath == null) {
                 analyzeByJSonPath = AnalyzeByJSonPath(content!!)
-                objectChangedJP = false
             }
             analyzeByJSonPath!!
         }

--- a/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeRule.kt
+++ b/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeRule.kt
@@ -54,6 +54,8 @@ class AnalyzeRule(
         private set
     var baseUrl: String? = null
         private set
+    var optionStr: String = "{}"
+        private set
     var redirectUrl: URL? = null
         private set
     private var isJSON: Boolean = false
@@ -91,6 +93,11 @@ class AnalyzeRule(
         baseUrl?.let {
             this.baseUrl = baseUrl
         }
+        return this
+    }
+
+    fun setOption(option: String): AnalyzeRule {
+        optionStr = option
         return this
     }
 
@@ -747,6 +754,7 @@ class AnalyzeRule(
             bindings["book"] = book
             bindings["result"] = result
             bindings["baseUrl"] = baseUrl
+            bindings["baseUrlWithOptions"] = "$baseUrl,$optionStr"
             bindings["chapter"] = chapter
             bindings["title"] = chapter?.title
             bindings["src"] = content

--- a/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeUrl.kt
+++ b/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeUrl.kt
@@ -193,8 +193,10 @@ class AnalyzeUrl(
             baseUrl = it
         }
         if (urlNoOption.length != ruleUrl.length) {
-            GSON.fromJsonObject<UrlOption>(ruleUrl.substring(urlMatcher.end())).getOrNull()
+            val optionStr = ruleUrl.substring(urlMatcher.end())
+            GSON.fromJsonObject<UrlOption>(optionStr).getOrNull()
                 ?.let { option ->
+                    this.optionStr = optionStr
                     option.getMethod()?.let {
                         if (it.equals("POST", true)) method = RequestMethod.POST
                     }

--- a/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeUrl.kt
+++ b/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeUrl.kt
@@ -76,6 +76,7 @@ class AnalyzeUrl(
     var type: String? = null
         private set
     val headerMap = HashMap<String, String>()
+    var optionStr: String = ""
     private var urlNoQuery: String = ""
     private var queryStr: String? = null
     private val fieldMap = LinkedHashMap<String, String>()

--- a/app/src/main/java/io/legado/app/model/webBook/BookList.kt
+++ b/app/src/main/java/io/legado/app/model/webBook/BookList.kt
@@ -43,7 +43,7 @@ object BookList {
         Debug.log(bookSource.bookSourceUrl, "≡获取成功:${analyzeUrl.ruleUrl}")
         Debug.log(bookSource.bookSourceUrl, body, state = 10)
         val analyzeRule = AnalyzeRule(ruleData, bookSource)
-        analyzeRule.setContent(body).setBaseUrl(baseUrl)
+        analyzeRule.setContent(body).setBaseUrl(baseUrl).setOption(analyzeUrl.optionStr)
         analyzeRule.setRedirectUrl(baseUrl)
         analyzeRule.setCoroutineContext(coroutineContext)
         if (isSearch) bookSource.bookUrlPattern?.let {

--- a/app/src/main/java/io/legado/app/ui/association/VerificationCodeDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/association/VerificationCodeDialog.kt
@@ -57,7 +57,6 @@ class VerificationCodeDialog() : BaseDialogFragment(R.layout.dialog_verification
     }
 
     private var sourceOrigin: String? = null
-    private var key = ""
 
     override fun onFragmentCreated(view: View, savedInstanceState: Bundle?): Unit = binding.run {
         initMenu()
@@ -65,7 +64,6 @@ class VerificationCodeDialog() : BaseDialogFragment(R.layout.dialog_verification
         toolBar.setBackgroundColor(primaryColor)
         toolBar.subtitle = arguments.getString("sourceName")
         sourceOrigin = arguments.getString("sourceOrigin")
-        key = SourceVerificationHelp.getKey(sourceOrigin!!)
         val imageUrl = arguments.getString("imageUrl") ?: return@run
         loadImage(imageUrl, sourceOrigin)
         verificationCodeImageView.setOnClickListener {
@@ -119,7 +117,7 @@ class VerificationCodeDialog() : BaseDialogFragment(R.layout.dialog_verification
         when (item.itemId) {
             R.id.menu_ok -> {
                 val verificationCode = binding.verificationCode.text.toString()
-                CacheManager.putMemory(key, verificationCode)
+                SourceVerificationHelp.setResult(sourceOrigin!!, verificationCode)
                 dismiss()
             }
         }
@@ -127,7 +125,7 @@ class VerificationCodeDialog() : BaseDialogFragment(R.layout.dialog_verification
     }
 
     override fun onDestroy() {
-        SourceVerificationHelp.checkResult(key)
+        SourceVerificationHelp.checkResult(sourceOrigin!!)
         super.onDestroy()
         activity?.finish()
     }

--- a/app/src/main/java/io/legado/app/ui/browser/WebViewActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/browser/WebViewActivity.kt
@@ -82,7 +82,7 @@ class WebViewActivity : VMBaseActivity<ActivityWebViewBinding, WebViewModel>() {
             R.id.menu_copy_url -> sendToClip(viewModel.baseUrl)
             R.id.menu_ok -> {
                 if (viewModel.sourceVerificationEnable) {
-                    viewModel.saveVerificationResult(intent) {
+                    viewModel.saveVerificationResult(binding.webView) {
                         finish()
                     }
                 } else {
@@ -224,7 +224,7 @@ class WebViewActivity : VMBaseActivity<ActivityWebViewBinding, WebViewModel>() {
                     if (it == "true") {
                         isCloudflareChallenge = true
                     } else if (isCloudflareChallenge && viewModel.sourceVerificationEnable) {
-                        viewModel.saveVerificationResult(intent) {
+                        viewModel.saveVerificationResult(binding.webView) {
                             finish()
                         }
                     }

--- a/app/src/main/java/io/legado/app/ui/browser/WebViewActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/browser/WebViewActivity.kt
@@ -158,7 +158,7 @@ class WebViewActivity : VMBaseActivity<ActivityWebViewBinding, WebViewModel>() {
     }
 
     override fun finish() {
-        SourceVerificationHelp.checkResult(viewModel.key)
+        SourceVerificationHelp.checkResult(viewModel.sourceOrigin)
         super.finish()
     }
 

--- a/app/src/main/java/io/legado/app/ui/browser/WebViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/browser/WebViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.util.Base64
 import android.webkit.URLUtil
+import android.webkit.WebView
 import androidx.documentfile.provider.DocumentFile
 import io.legado.app.base.BaseViewModel
 import io.legado.app.constant.AppConst
@@ -22,14 +23,17 @@ import io.legado.app.utils.isContentScheme
 import io.legado.app.utils.printOnDebug
 import io.legado.app.utils.toastOnUi
 import io.legado.app.utils.writeBytes
+import org.apache.commons.text.StringEscapeUtils
 import java.io.File
 import java.util.Date
 
 class WebViewModel(application: Application) : BaseViewModel(application) {
+    var intent: Intent? = null
     var baseUrl: String = ""
     var html: String? = null
     val headerMap: HashMap<String, String> = hashMapOf()
     var sourceVerificationEnable: Boolean = false
+    var refetchAfterSuccess: Boolean = true
     var sourceOrigin: String = ""
 
     fun initData(
@@ -37,10 +41,12 @@ class WebViewModel(application: Application) : BaseViewModel(application) {
         success: () -> Unit
     ) {
         execute {
+            this@WebViewModel.intent = intent
             val url = intent.getStringExtra("url")
                 ?: throw NoStackTraceException("url不能为空")
             sourceOrigin = intent.getStringExtra("sourceOrigin") ?: ""
             sourceVerificationEnable = intent.getBooleanExtra("sourceVerificationEnable", false)
+            refetchAfterSuccess = intent.getBooleanExtra("refetchAfterSuccess", true)
             val headerMapF = IntentData.get<Map<String, String>>(url)
             val analyzeUrl = AnalyzeUrl(url, headerMapF = headerMapF)
             baseUrl = analyzeUrl.url
@@ -89,10 +95,13 @@ class WebViewModel(application: Application) : BaseViewModel(application) {
         }
     }
 
-    fun saveVerificationResult(intent: Intent, success: () -> Unit) {
-        execute {
-            if (sourceVerificationEnable) {
-                val url = intent.getStringExtra("url")!!
+    fun saveVerificationResult(webView: WebView, success: () -> Unit) {
+        if (!sourceVerificationEnable) {
+            execute { success.invoke() }
+        }
+        if (refetchAfterSuccess) {
+            execute {
+                val url = intent!!.getStringExtra("url")!!
                 val source = appDb.bookSourceDao.getBookSource(sourceOrigin)
                 html = AnalyzeUrl(
                     url,
@@ -100,9 +109,16 @@ class WebViewModel(application: Application) : BaseViewModel(application) {
                     source = source
                 ).getStrResponseAwait(useWebView = false).body
                 SourceVerificationHelp.setResult(sourceOrigin, html ?: "")
+                success.invoke()
             }
-        }.onSuccess {
-            success.invoke()
+        } else {
+            webView.evaluateJavascript("document.documentElement.outerHTML") {
+                execute {
+                    html = StringEscapeUtils.unescapeJson(it).trim('"')
+                    SourceVerificationHelp.setResult(sourceOrigin, html ?: "")
+                    success.invoke()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/io/legado/app/ui/browser/WebViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/browser/WebViewModel.kt
@@ -31,7 +31,6 @@ class WebViewModel(application: Application) : BaseViewModel(application) {
     val headerMap: HashMap<String, String> = hashMapOf()
     var sourceVerificationEnable: Boolean = false
     var sourceOrigin: String = ""
-    var key = ""
 
     fun initData(
         intent: Intent,
@@ -41,7 +40,6 @@ class WebViewModel(application: Application) : BaseViewModel(application) {
             val url = intent.getStringExtra("url")
                 ?: throw NoStackTraceException("url不能为空")
             sourceOrigin = intent.getStringExtra("sourceOrigin") ?: ""
-            key = SourceVerificationHelp.getKey(sourceOrigin)
             sourceVerificationEnable = intent.getBooleanExtra("sourceVerificationEnable", false)
             val headerMapF = IntentData.get<Map<String, String>>(url)
             val analyzeUrl = AnalyzeUrl(url, headerMapF = headerMapF)
@@ -96,13 +94,12 @@ class WebViewModel(application: Application) : BaseViewModel(application) {
             if (sourceVerificationEnable) {
                 val url = intent.getStringExtra("url")!!
                 val source = appDb.bookSourceDao.getBookSource(sourceOrigin)
-                val key = "${sourceOrigin}_verificationResult"
                 html = AnalyzeUrl(
                     url,
                     headerMapF = headerMap,
                     source = source
                 ).getStrResponseAwait(useWebView = false).body
-                CacheManager.putMemory(key, html ?: "")
+                SourceVerificationHelp.setResult(sourceOrigin, html ?: "")
             }
         }.onSuccess {
             success.invoke()


### PR DESCRIPTION
# 目前验证流程存在的问题
使用 `res = java.startBrowserAwait` 手动验证过后，`res.body()` 调用因重获取数据逻辑导致无法得到点击确认按钮时网页显示的结果：
![Pasted image 20240907104533](https://github.com/user-attachments/assets/b5a94a4c-1eaf-4e07-8ead-228886b5c71f)
重获取结果如下：
![Pasted image 20240907104716](https://github.com/user-attachments/assets/31ba5840-e7d1-4e3c-b677-b15689509438)
此时应该使用 webview 打开链接页面，或直接返回用户看见的页面。

- 从用户（书源编写者）的角度来说，我更期望点击按钮时返回的是我看见的页面的源码，而不是重获取的源码，因为如果需要使用 webview 请求页面的话，我会在发起请求时使用 `"webView": true` 来指定，这里我更倾向于直接返回用户看见的页面。
- 从 legado 维护者的角度来说，这一改动不应该影响已有书源（重获取的页面源码与 webview 中 js 处理过的源码可能不一样），除非是大版本的不兼容升级，这里应该由用户决定是直接使用页面源码还是重获取，应该在外部加一个开关来控制。

# 问题修复方案
1. `startBrowserAwait` 接口提供新参数 `refetchAfterSuccess`，让用户选择是否进行重新获取，默认值为 true
2. 在解析逻辑中添加 `baseUrlWithOptions` 变量，让用户可以使用该变量值进行 `startBrowserAwait` 调用

# 其他改动说明
1. pr 中存在重构改动，改动 commit 分别为 [移除冗余变量](https://github.com/gedoor/legado/pull/4193/commits/88cabef11e876a80c840166b437d8e02a0e3515f)、[收拢验证结果获取与设置逻辑](https://github.com/gedoor/legado/pull/4193/commits/a3fa748a7451c5e84fe0b86b23d69c2b20df04b4) 与 [重命名验证流程的 key 为 verificationResultKey](https://github.com/gedoor/legado/pull/4193/commits/8bfa1d31299176cdff69a2f20b61817cbdeb33aa)

# 关联 issues
#2507 