### PR TITLE
UI:阅读页面底部区域显示章节, 菜单顶部显示书名, 电纸书主题下顶部和底部信息区不需要增加padding.

### DIFF
--- a/app/src/main/java/io/legado/app/help/config/ReadTipConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/ReadTipConfig.kt
@@ -8,14 +8,14 @@ import splitties.init.appCtx
 object ReadTipConfig {
 
     const val none = 0
-    const val chapterTitle = 1
+    const val bookName = 1
     const val time = 2
     const val battery = 3
     const val batteryPercentage = 10
     const val page = 4
     const val totalProgress = 5
     const val pageAndTotal = 6
-    const val bookName = 7
+    const val chapterTitle = 7
     const val timeBattery = 8
     const val timeBatteryPercentage = 9
     const val totalProgress1 = 11

--- a/app/src/main/java/io/legado/app/ui/book/read/page/PageView.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/PageView.kt
@@ -11,6 +11,7 @@ import io.legado.app.R
 import io.legado.app.constant.AppConst.timeFormat
 import io.legado.app.data.entities.Bookmark
 import io.legado.app.databinding.ViewBookPageBinding
+import io.legado.app.help.config.AppConfig
 import io.legado.app.help.config.ReadBookConfig
 import io.legado.app.help.config.ReadTipConfig
 import io.legado.app.model.ReadBook
@@ -92,18 +93,20 @@ class PageView(context: Context) : FrameLayout(context) {
             vwTopDivider.backgroundColor = tipDividerColor
             vwBottomDivider.backgroundColor = tipDividerColor
             upStatusBar()
-            llHeader.setPadding(
-                it.headerPaddingLeft.dpToPx(),
-                it.headerPaddingTop.dpToPx(),
-                it.headerPaddingRight.dpToPx(),
-                it.headerPaddingBottom.dpToPx()
-            )
-            llFooter.setPadding(
-                it.footerPaddingLeft.dpToPx(),
-                it.footerPaddingTop.dpToPx(),
-                it.footerPaddingRight.dpToPx(),
-                it.footerPaddingBottom.dpToPx()
-            )
+            if (!AppConfig.isEInkMode) {
+                llHeader.setPadding(
+                    it.headerPaddingLeft.dpToPx(),
+                    it.headerPaddingTop.dpToPx(),
+                    it.headerPaddingRight.dpToPx(),
+                    it.headerPaddingBottom.dpToPx()
+                )
+                llFooter.setPadding(
+                    it.footerPaddingLeft.dpToPx(),
+                    it.footerPaddingTop.dpToPx(),
+                    it.footerPaddingRight.dpToPx(),
+                    it.footerPaddingBottom.dpToPx()
+                )
+            }
             vwTopDivider.gone(llHeader.isGone || !it.showHeaderLine)
             vwBottomDivider.gone(llFooter.isGone || !it.showFooterLine)
         }
@@ -146,8 +149,8 @@ class PageView(context: Context) : FrameLayout(context) {
             tvFooterRight.isGone = tipFooterRight == none
             tvFooterMiddle.isGone = tipFooterMiddle == none
         }
-        tvTitle = getTipView(ReadTipConfig.chapterTitle)?.apply {
-            tag = ReadTipConfig.chapterTitle
+        tvBookName = getTipView(ReadTipConfig.bookName)?.apply {
+            tag = ReadTipConfig.bookName
             isBattery = false
             typeface = ChapterProvider.typeface
             textSize = 12f
@@ -187,8 +190,8 @@ class PageView(context: Context) : FrameLayout(context) {
             typeface = ChapterProvider.typeface
             textSize = 12f
         }
-        tvBookName = getTipView(ReadTipConfig.bookName)?.apply {
-            tag = ReadTipConfig.bookName
+        tvTitle = getTipView(ReadTipConfig.chapterTitle)?.apply {
+            tag = ReadTipConfig.chapterTitle
             isBattery = false
             typeface = ChapterProvider.typeface
             textSize = 12f


### PR DESCRIPTION
阅读页面底部区域显示章节:(电纸书主题下顶部和底部信息区不需要增加padding)
![Screenshot_20240929_013923](https://github.com/user-attachments/assets/7caf93c0-509e-46f0-8a40-6f95f248fdfe)
菜单顶部显示书名:
![Screenshot_20240929_014029](https://github.com/user-attachments/assets/eee63bf6-2dab-4d55-b679-18b4b876113c)
