### PR TITLE
优化rss加载逻辑

### DIFF
--- a/app/src/main/java/io/legado/app/data/dao/RssArticleDao.kt
+++ b/app/src/main/java/io/legado/app/data/dao/RssArticleDao.kt
@@ -23,6 +23,9 @@ interface RssArticleDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(vararg rssArticle: RssArticle)
 
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun append(vararg rssArticle: RssArticle)
+
     @Query("delete from rssArticles where origin = :origin and sort = :sort and `order` < :order")
     fun clearOld(origin: String, sort: String, order: Long)
 

--- a/app/src/main/java/io/legado/app/ui/rss/article/RssArticlesViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/rss/article/RssArticlesViewModel.kt
@@ -80,14 +80,16 @@ class RssArticlesViewModel(application: Application) : BaseViewModel(application
             return
         }
         val firstArticle = articles.first()
-        val dbArticle = appDb.rssArticleDao.get(firstArticle.origin, firstArticle.link)
-        if (dbArticle != null) {
+        val dbFirstArticle = appDb.rssArticleDao.get(firstArticle.origin, firstArticle.link)
+        val lastArticle = articles.last()
+        val dbLastArticle = appDb.rssArticleDao.get(lastArticle.origin, lastArticle.link)
+        if (dbFirstArticle != null && dbLastArticle != null) {
             loadFinallyLiveData.postValue(false)
         } else {
             articles.forEach {
                 it.order = order--
             }
-            appDb.rssArticleDao.insert(*articles.toTypedArray())
+            appDb.rssArticleDao.append(*articles.toTypedArray())
         }
     }
 


### PR DESCRIPTION
个别网站分页逻辑存在问题，下一页会出现之前的数据，一旦该数据出现在第一条会导致之后的分页无法加载，同时判断第一条和最后一条，可以避免这种情况出现。
append方法，确保可以将重复的数据过滤掉，只追加新的数据。