### PR TITLE
新增使用scheme跳转其他应用的方法

### DIFF
--- a/app/src/main/java/io/legado/app/help/JsExtensions.kt
+++ b/app/src/main/java/io/legado/app/help/JsExtensions.kt
@@ -1,5 +1,6 @@
 package io.legado.app.help
 
+import android.content.Intent
 import android.net.Uri
 import android.webkit.WebSettings
 import androidx.annotation.Keep
@@ -945,4 +946,12 @@ interface JsExtensions : JsEncodeUtils {
         return AppConst.androidId
     }
 
+    /**
+     * 新增使用scheme跳转其他应用方法
+     */
+    fun openScheme(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        appCtx.startActivity(intent)
+    }
 }


### PR DESCRIPTION
- 在 JsExtensions.kt 文件中添加了 openScheme 函数 -该函数通过 Intent.ACTION_VIEW 启动其他应用的特定页面
- 使用 Uri.parse(url) 解析传入的 scheme URL
- 添加了 Intent.FLAG_ACTIVITY_NEW_TASK 标志，确保在新任务中启动目标应用