### PR TITLE
rss阅读记录单行显示，可滑动查看

### DIFF
--- a/app/src/main/java/io/legado/app/ui/rss/article/ReadRecordDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/rss/article/ReadRecordDialog.kt
@@ -2,6 +2,7 @@ package io.legado.app.ui.rss.article
 
 import android.content.Context
 import android.os.Bundle
+import android.text.method.ScrollingMovementMethod
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
@@ -76,6 +77,8 @@ class ReadRecordDialog : BaseDialogFragment(R.layout.dialog_recycler_view),
             item: RssReadRecord,
             payloads: MutableList<Any>
         ) {
+            binding.textTitle.movementMethod = ScrollingMovementMethod()
+            binding.textRecord.movementMethod = ScrollingMovementMethod()
             binding.textTitle.text = item.title
             binding.textRecord.text = item.record
         }

--- a/app/src/main/res/layout/item_rss_read_record.xml
+++ b/app/src/main/res/layout/item_rss_read_record.xml
@@ -6,19 +6,31 @@
     android:background="?android:attr/selectableItemBackground"
     android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/text_title"
-        android:text="@string/title"
+    <HorizontalScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textIsSelectable="true" />
+        android:layout_height="match_parent"
+        android:scrollbars="none">
+        <TextView
+            android:id="@+id/text_title"
+            android:text="@string/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:singleLine="true"
+            android:ellipsize="none" />
+    </HorizontalScrollView>
 
-    <TextView
-        android:id="@+id/text_record"
-        android:text="@string/read_record"
+    <HorizontalScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:autoLink="web"
-        android:textIsSelectable="true" />
+        android:layout_height="match_parent"
+        android:scrollbars="none">
+        <TextView
+            android:id="@+id/text_record"
+            android:text="@string/read_record"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:autoLink="web"
+            android:singleLine="true"
+            android:ellipsize="none" />
+    </HorizontalScrollView>
 
 </LinearLayout>


### PR DESCRIPTION
避免标题或连接过长换行显示