### PR TITLE
增加漫画缓存自动清除功能

### DIFF
--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -93,6 +93,7 @@ object PreferKey {
     const val cronet = "Cronet"
     const val antiAlias = "antiAlias"
     const val bitmapCacheSize = "bitmapCacheSize"
+    const val bitmapRetainNum = "bitmapRetainNum"
     const val preDownloadNum = "preDownloadNum"
     const val autoRefresh = "auto_refresh"
     const val defaultToRead = "defaultToRead"

--- a/app/src/main/java/io/legado/app/help/config/AppConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfig.kt
@@ -554,6 +554,12 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
             appCtx.putPrefInt(PreferKey.bitmapCacheSize, value)
         }
 
+    var bitmapRetainNum: Int
+        get() = appCtx.getPrefInt(PreferKey.bitmapRetainNum, 0)
+        set(value) {
+            appCtx.putPrefInt(PreferKey.bitmapRetainNum, value)
+        }
+
     var showReadTitleBarAddition: Boolean
         get() = appCtx.getPrefBoolean(PreferKey.showReadTitleAddition, true)
         set(value) {

--- a/app/src/main/java/io/legado/app/ui/config/OtherConfigFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/config/OtherConfigFragment.kt
@@ -68,6 +68,7 @@ class OtherConfigFragment : PreferenceFragment(),
         }
         upPreferenceSummary(PreferKey.checkSource, CheckSource.summary)
         upPreferenceSummary(PreferKey.bitmapCacheSize, AppConfig.bitmapCacheSize.toString())
+        upPreferenceSummary(PreferKey.bitmapRetainNum, AppConfig.bitmapRetainNum.toString())
         upPreferenceSummary(PreferKey.sourceEditMaxLine, AppConfig.sourceEditMaxLine.toString())
     }
 
@@ -132,6 +133,14 @@ class OtherConfigFragment : PreferenceFragment(),
                         ImageProvider.bitmapLruCache.resize(ImageProvider.cacheSize)
                     }
             }
+            PreferKey.bitmapRetainNum -> NumberPickerDialog(requireContext())
+                .setTitle(getString(R.string.bitmap_retain_number))
+                .setMaxValue(999)
+                .setMinValue(0)
+                .setValue(AppConfig.bitmapRetainNum)
+                .show {
+                    AppConfig.bitmapRetainNum = it
+                }
 
             PreferKey.sourceEditMaxLine -> {
                 NumberPickerDialog(requireContext())
@@ -203,6 +212,10 @@ class OtherConfigFragment : PreferenceFragment(),
                 upPreferenceSummary(key, AppConfig.bitmapCacheSize.toString())
             }
 
+            PreferKey.bitmapRetainNum -> {
+                upPreferenceSummary(key, AppConfig.bitmapRetainNum.toString())
+            }
+
             PreferKey.sourceEditMaxLine -> {
                 upPreferenceSummary(key, AppConfig.sourceEditMaxLine.toString())
             }
@@ -219,6 +232,8 @@ class OtherConfigFragment : PreferenceFragment(),
             PreferKey.webPort -> preference.summary = getString(R.string.web_port_summary, value)
             PreferKey.bitmapCacheSize -> preference.summary =
                 getString(R.string.bitmap_cache_size_summary, value)
+            PreferKey.bitmapRetainNum -> preference.summary =
+                getString(R.string.bitmap_retain_number_summary, value)
 
             PreferKey.sourceEditMaxLine -> preference.summary =
                 getString(R.string.source_edit_max_line_summary, value)

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1003,6 +1003,8 @@
     <string name="add_remote_book">RemoteBook</string>
     <string name="bitmap_cache_size_summary">Current cache max size %1$s MB</string>
     <string name="bitmap_cache_size">bitmap cache size</string>
+    <string name="bitmap_retain_number_summary">Keep the number of chapters read %s</string>
+    <string name="bitmap_retain_number">Number of manga reservations</string>
     <string name="export_pics_file">Export Picture Files</string>
     <!-- string end -->
     <string name="error_decode_bitmap">Fail to decode bitmap</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -1006,6 +1006,8 @@
     <string name="add_remote_book">RemoteBook</string>
     <string name="bitmap_cache_size_summary">Current cache max size %1$s MB</string>
     <string name="bitmap_cache_size">bitmap cache size</string>
+    <string name="bitmap_retain_number_summary">保留已读章节数量 %s</string>
+    <string name="bitmap_retain_number">漫画保留数量</string>
     <string name="export_pics_file">Export Picture Files</string>
     <!-- string end -->
     <string name="error_decode_bitmap">Fail to decode bitmap</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1006,6 +1006,8 @@
     <string name="add_remote_book">RemoteBook</string>
     <string name="bitmap_cache_size_summary">Current cache max size %1$s MB</string>
     <string name="bitmap_cache_size">bitmap cache size</string>
+    <string name="bitmap_retain_number_summary">Keep the number of chapters read %s</string>
+    <string name="bitmap_retain_number">Number of manga reservations</string>
     <string name="export_pics_file">Export Picture Files</string>
     <!-- string end -->
     <string name="error_decode_bitmap">Fail to decode bitmap</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1003,6 +1003,8 @@ Còn </string>
     <string name="add_remote_book">Sách từ xa</string>
     <string name="bitmap_cache_size_summary">Kích thước tối đa của bộ đệm hiện tại %1$s MB</string>
     <string name="bitmap_cache_size">kích thước bộ đệm bitmap</string>
+    <string name="bitmap_retain_number_summary">Giữ số chương đã đọc %s</string>
+    <string name="bitmap_retain_number">Số lượng đặt chỗ manga</string>
     <string name="export_pics_file">Xuất tập tin ảnh</string>
     <!-- string end -->
     <string name="error_decode_bitmap">Không thể giải mã bitmap</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1003,6 +1003,8 @@
     <string name="add_remote_book">远程书籍</string>
     <string name="bitmap_cache_size_summary">当前最大缓存 %1$s MB</string>
     <string name="bitmap_cache_size">图片绘制缓存</string>
+    <string name="bitmap_retain_number_summary">保留已讀章節數量 %s</string>
+    <string name="bitmap_retain_number">漫畫保留數量</string>
     <string name="export_pics_file">TXT导出图片</string>
     <!-- string end -->
     <string name="error_decode_bitmap">图片解码失败</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1005,6 +1005,8 @@
     <string name="add_remote_book">远程書籍</string>
     <string name="bitmap_cache_size_summary">目前最大快取 %1$s MB</string>
     <string name="bitmap_cache_size">圖片繪製快取</string>
+    <string name="bitmap_retain_number_summary">保留已讀章節數量 %s</string>
+    <string name="bitmap_retain_number">漫畫保留數量</string>
     <string name="export_pics_file">TXT匯出圖片</string>
     <!-- string end -->
     <string name="error_decode_bitmap">圖片解碼失敗</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1006,6 +1006,8 @@
     <string name="add_remote_book">远程书籍</string>
     <string name="bitmap_cache_size_summary">当前最大缓存 %1$s MB</string>
     <string name="bitmap_cache_size">图片绘制缓存</string>
+    <string name="bitmap_retain_number_summary">保留已读章节数量 %s</string>
+    <string name="bitmap_retain_number">漫画保留数量</string>
     <string name="export_pics_file">TXT 导出图片</string>
     <!-- string end -->
     <string name="error_decode_bitmap">图片解码失败</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1009,6 +1009,8 @@
     <string name="add_remote_book">RemoteBook</string>
     <string name="bitmap_cache_size_summary">Current cache max size %1$s MB</string>
     <string name="bitmap_cache_size">bitmap cache size</string>
+    <string name="bitmap_retain_number_summary">Keep the number of chapters read %s</string>
+    <string name="bitmap_retain_number">Number of manga reservations</string>
     <string name="export_pics_file">Export Picture Files</string>
     <!-- string end -->
     <string name="error_decode_bitmap">Fail to decode bitmap</string>

--- a/app/src/main/res/xml/pref_config_other.xml
+++ b/app/src/main/res/xml/pref_config_other.xml
@@ -110,6 +110,11 @@
             android:title="@string/bitmap_cache_size" />
 
         <io.legado.app.lib.prefs.Preference
+            android:key="bitmapRetainNum"
+            android:summary="@string/bitmap_retain_number_summary"
+            android:title="@string/bitmap_retain_number" />
+
+        <io.legado.app.lib.prefs.Preference
             android:key="preDownloadNum"
             android:summary="@string/pre_download_s"
             android:title="@string/pre_download" />


### PR DESCRIPTION
https://github.com/gedoor/legado/issues/4637
增加漫画书籍清除缓存功能，其他设置中增加保留章节数选项，默认为0不进行清除。