### PR TITLE
fix: 章节内容存在多张图片和文本时，web服务书架中读书无法正确渲染图片

### DIFF
--- a/modules/web/src/views/BookChapter.vue
+++ b/modules/web/src/views/BookChapter.vue
@@ -305,6 +305,11 @@ const getContent = (index: number, reloadChapter = true, chapterPos = 0) => {
         if (res.data.isSuccess) {
           const data = res.data.data
           const content = data.split(/\n+/)
+          for (let i = 0; i < content.length; i++) {
+            if (!/^\s*<img[^>]*src[^>]+>$/.test(content[i])) {
+              content[i] = content[i].replaceAll('img src="', `img src="/image?url=${bookUrl}&path=`);
+            }
+          }
           chapterData.value.push({ index, content, title })
           if (reloadChapter) toChapterPos(chapterPos)
         } else {


### PR DESCRIPTION
章节内容存在多张图片和文本时，web服务书架中读书无法正确渲染图片(src未处理)。
以下图片为未修复状态下:
![image](https://github.com/user-attachments/assets/cb971e7c-d30c-4058-8bde-2c93a06f4950)

以下图片为已修复状态下
![image](https://github.com/user-attachments/assets/37b47978-468b-408d-ae7f-af49084f4004)
