### PR TITLE
fix web书架读书章节内容存在多张图片时代理图片url中的bookUrl参数未encodeURIComponent导致的图片无法访问

### DIFF
--- a/modules/web/src/views/BookChapter.vue
+++ b/modules/web/src/views/BookChapter.vue
@@ -305,9 +305,10 @@ const getContent = (index: number, reloadChapter = true, chapterPos = 0) => {
         if (res.data.isSuccess) {
           const data = res.data.data
           const content = data.split(/\n+/)
+          const urlEncodedBookUrl = encodeURIComponent(bookUrl)
           for (let i = 0; i < content.length; i++) {
             if (!/^\s*<img[^>]*src[^>]+>$/.test(content[i])) {
-              content[i] = content[i].replace(new RegExp('img src="', 'g'), `img src="/image?url=${bookUrl}&path=`);
+              content[i] = content[i].replace(new RegExp('img src="', 'g'), `img src="/image?url=${urlEncodedBookUrl}&path=`);
             }
           }
           chapterData.value.push({ index, content, title })


### PR DESCRIPTION
web书架读书章节内容存在多张图片时代理图片url中的bookUrl参数未encodeURIComponent导致的图片无法访问