### PR TITLE
处理内置浏览器函数本地html跨域、目录章节信息排版优化

### DIFF
--- a/app/src/main/assets/web/help/md/jsHelp.md
+++ b/app/src/main/assets/web/help/md/jsHelp.md
@@ -141,10 +141,14 @@ java.webViewGetSource(html: String?, url: String?, js: String?, sourceRegex: Str
 * 使用内置浏览器打开链接，可用于获取验证码 手动验证网站防爬
 * @param url 要打开的链接
 * @param title 浏览器的标题
+* @param html 本地html代码
 java.startBrowser(url: String, title: String)
+java.startBrowser(url: String, title: String, html: String)
 
 * 使用内置浏览器打开链接，并等待网页结果 .body()获取网页内容
+* @param refetchAfterSuccess 为false时获取最终界面源码
 java.startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean? = true): StrResponse
+java.startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean? = true, html: String): StrResponse
 ```
 * 调试
 ```js

--- a/app/src/main/assets/web/help/md/jsHelp.md
+++ b/app/src/main/assets/web/help/md/jsHelp.md
@@ -143,12 +143,16 @@ java.webViewGetSource(html: String?, url: String?, js: String?, sourceRegex: Str
 * @param title 浏览器的标题
 * @param html 本地html代码
 java.startBrowser(url: String, title: String)
-java.startBrowser(url: String, title: String, html: String)
+
+java.startBrowser(url: String, title: String, html: String?)
 
 * 使用内置浏览器打开链接，并等待网页结果 .body()获取网页内容
-* @param refetchAfterSuccess 为false时获取最终界面源码
-java.startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean? = true): StrResponse
-java.startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean? = true, html: String): StrResponse
+* @param refetchAfterSuccess 为false时获取最终展示界面的源码
+java.startBrowserAwait(url: String, title: String): StrResponse
+
+java.startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean): StrResponse
+
+java.startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean, html: String?): StrResponse
 ```
 * 调试
 ```js

--- a/app/src/main/java/io/legado/app/help/JsExtensions.kt
+++ b/app/src/main/java/io/legado/app/help/JsExtensions.kt
@@ -242,16 +242,20 @@ interface JsExtensions : JsEncodeUtils {
     /**
      * 使用内置浏览器打开链接，并等待网页结果
      */
-    fun startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean): StrResponse {
+     fun startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean, html: String?): StrResponse {
         rhinoContext.ensureActive()
         val body = SourceVerificationHelp.getVerificationResult(
-            getSource(), url, title, true, refetchAfterSuccess
+            getSource(), url, title, true, refetchAfterSuccess, html
         )
         return StrResponse(url, body)
     }
 
+    fun startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean): StrResponse {
+        return startBrowserAwait(url, title, refetchAfterSuccess, null)
+    }
+
     fun startBrowserAwait(url: String, title: String): StrResponse {
-        return startBrowserAwait(url, title, true)
+        return startBrowserAwait(url, title, true, null)
     }
 
     /**

--- a/app/src/main/java/io/legado/app/help/JsExtensions.kt
+++ b/app/src/main/java/io/legado/app/help/JsExtensions.kt
@@ -231,8 +231,12 @@ interface JsExtensions : JsEncodeUtils {
      * @param title 浏览器页面的标题
      */
     fun startBrowser(url: String, title: String) {
+        return startBrowser(url, title, null)
+    }
+
+    fun startBrowser(url: String, title: String, html: String?) {
         rhinoContext.ensureActive()
-        SourceVerificationHelp.startBrowser(getSource(), url, title)
+        SourceVerificationHelp.startBrowser(getSource(), url, title, html=html)
     }
 
     /**

--- a/app/src/main/java/io/legado/app/help/JsExtensions.kt
+++ b/app/src/main/java/io/legado/app/help/JsExtensions.kt
@@ -242,20 +242,20 @@ interface JsExtensions : JsEncodeUtils {
     /**
      * 使用内置浏览器打开链接，并等待网页结果
      */
-     fun startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean, html: String?): StrResponse {
-        rhinoContext.ensureActive()
-        val body = SourceVerificationHelp.getVerificationResult(
-            getSource(), url, title, true, refetchAfterSuccess, html
-        )
-        return StrResponse(url, body)
+    fun startBrowserAwait(url: String, title: String): StrResponse {
+        return startBrowserAwait(url, title, true, null)
     }
 
     fun startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean): StrResponse {
         return startBrowserAwait(url, title, refetchAfterSuccess, null)
     }
 
-    fun startBrowserAwait(url: String, title: String): StrResponse {
-        return startBrowserAwait(url, title, true, null)
+    fun startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean, html: String?): StrResponse {
+        rhinoContext.ensureActive()
+        val body = SourceVerificationHelp.getVerificationResult(
+            getSource(), url, title, true, refetchAfterSuccess, html
+        )
+        return StrResponse(url, body)
     }
 
     /**

--- a/app/src/main/java/io/legado/app/help/source/SourceVerificationHelp.kt
+++ b/app/src/main/java/io/legado/app/help/source/SourceVerificationHelp.kt
@@ -81,7 +81,8 @@ object SourceVerificationHelp {
         url: String,
         title: String,
         saveResult: Boolean? = false,
-        refetchAfterSuccess: Boolean? = true
+        refetchAfterSuccess: Boolean? = true,
+        html: String? = null
     ) {
         source ?: throw NoStackTraceException("startBrowser parameter source cannot be null")
         require(url.length < 64 * 1024) { "startBrowser parameter url too long" }
@@ -93,6 +94,9 @@ object SourceVerificationHelp {
             putExtra("sourceType", source.getSourceType())
             putExtra("sourceVerificationEnable", saveResult)
             putExtra("refetchAfterSuccess", refetchAfterSuccess)
+            if (html != null) {
+                putExtra("html", html)
+            }
             IntentData.put(getVerificationResultKey(source), Thread.currentThread())
         }
     }

--- a/app/src/main/java/io/legado/app/help/source/SourceVerificationHelp.kt
+++ b/app/src/main/java/io/legado/app/help/source/SourceVerificationHelp.kt
@@ -35,7 +35,8 @@ object SourceVerificationHelp {
         url: String,
         title: String,
         useBrowser: Boolean,
-        refetchAfterSuccess: Boolean = true
+        refetchAfterSuccess: Boolean = true,
+        html: String? = null
     ): String {
         source
             ?: throw NoStackTraceException("getVerificationResult parameter source cannot be null")
@@ -53,7 +54,7 @@ object SourceVerificationHelp {
                 IntentData.put(getVerificationResultKey(source), Thread.currentThread())
             }
         } else {
-            startBrowser(source, url, title, true, refetchAfterSuccess)
+            startBrowser(source, url, title, true, refetchAfterSuccess, html)
         }
 
         var waitUserInput = false

--- a/app/src/main/java/io/legado/app/ui/book/read/page/provider/TextChapterLayout.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/provider/TextChapterLayout.kt
@@ -257,77 +257,54 @@ class TextChapterLayout(
                     prepareNextPageIfNeed()
                 }
                 var start = 0
-                val currentText = StringBuilder()
-                val currentSrcList = LinkedList<String>()
-                val matcher = AppPattern.imgPattern.matcher(content)
-                var text = content.replace(ChapterProvider.srcReplaceChar, "▣")
-                while (matcher.find()) {
-                    coroutineContext.ensureActive()
-                    val textBefore = text.substring(start, matcher.start())
-                    if (textBefore.isNotBlank()) {
-                        currentText.append(textBefore)
-                    }
-                    start = matcher.end()
-                    val imgSrc = matcher.group(1)!!
-                    val imgSize = ImageProvider.getImageSize(book, imgSrc, ReadBook.bookSource)
-                    val isSmallImage = imgSize.width < 80 && imgSize.height < 80
-                    if (isSmallImage) {
-                        // 小图片：添加占位符并记录源
-                        currentText.append(ChapterProvider.srcReplaceChar)
-                        currentSrcList.add(imgSrc)
-                    } else {
-                        // 大图片：先处理累积的文本
-                        if (currentText.isNotEmpty()) {
+                if (content.contains("<img")) {
+                    val matcher = AppPattern.imgPattern.matcher(content)
+                    while (matcher.find()) {
+                        coroutineContext.ensureActive()
+                        val text = content.substring(start, matcher.start())
+                        if (text.isNotBlank()) {
                             setTypeText(
                                 book,
-                                currentText.toString(),
+                                text,
                                 contentPaint,
                                 contentPaintTextHeight,
                                 contentPaintFontMetrics,
                                 imageStyle,
-                                isFirstLine = start == 0,
-                                srcList = currentSrcList
+                                isFirstLine = start == 0
                             )
-                            currentText.clear()
                         }
-                        // 处理大图片（会触发换行）
                         setTypeImage(
                             book,
-                            imgSrc,
+                            matcher.group(1)!!,
                             contentPaintTextHeight,
                             imageStyle
                         )
                         isSetTypedImage = true
+                        start = matcher.end()
                     }
                 }
-                // 处理剩余的文本
-                if (start < text.length) {
+                if (start < content.length) {
                     if (isSingleImageStyle && isSetTypedImage) {
                         isSetTypedImage = false
                         prepareNextPageIfNeed()
                     }
-                    val textAfter = text.substring(start, text.length)
-                    if (textAfter.isNotBlank()) {
-                        currentText.append(textAfter)
+                    val text = content.substring(start, content.length)
+                    if (text.isNotBlank()) {
+                        setTypeText(
+                            book,
+                            if (AppConfig.enableReview) text + ChapterProvider.reviewChar else text,
+                            contentPaint,
+                            contentPaintTextHeight,
+                            contentPaintFontMetrics,
+                            imageStyle,
+                            isFirstLine = start == 0
+                        )
                     }
-                }
-                // 处理剩余的累积文本
-                if (currentText.isNotEmpty()) {
-                    setTypeText(
-                    book,
-                    if (AppConfig.enableReview) currentText.toString() + ChapterProvider.reviewChar else currentText.toString(),
-                    contentPaint,
-                    contentPaintTextHeight,
-                    contentPaintFontMetrics,
-                    imageStyle,
-                    isFirstLine = start == 0,
-                    srcList = if (currentSrcList.isNotEmpty()) currentSrcList else null
-                    )
                 }
             }
             pendingTextPage.lines.last().isParagraphEnd = true
             stringBuilder.append("\n")
-    }
+        }
         val textPage = pendingTextPage
         val endPadding = 20.dpToPx()
         val durYPadding = durY + endPadding

--- a/app/src/main/java/io/legado/app/ui/book/toc/ChapterListAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/ChapterListAdapter.kt
@@ -143,8 +143,8 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
                         ThemeUtils.resolveDrawable(context, android.R.attr.selectableItemBackground)
                 }
 
-                //卷名不显示
-                if (!item.tag.isNullOrEmpty() && !item.isVolume) {
+                //卷名不显示 去掉了 !item.isVolume，让卷名也显示
+                if (!item.tag.isNullOrEmpty()) {
                     //更新时间规则
                     tvTag.text = item.tag
                     tvTag.visible()

--- a/app/src/main/java/io/legado/app/ui/browser/WebViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/browser/WebViewModel.kt
@@ -51,6 +51,7 @@ class WebViewModel(application: Application) : BaseViewModel(application) {
             sourceType = intent.getIntExtra("sourceType", SourceType.book)
             sourceVerificationEnable = intent.getBooleanExtra("sourceVerificationEnable", false)
             refetchAfterSuccess = intent.getBooleanExtra("refetchAfterSuccess", true)
+            html = intent.getStringExtra("html")
             val source = SourceHelp.getSource(sourceOrigin, sourceType)
             val analyzeUrl = AnalyzeUrl(url, source = source, coroutineContext = coroutineContext)
             baseUrl = analyzeUrl.url

--- a/app/src/main/java/io/legado/app/ui/browser/WebViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/browser/WebViewModel.kt
@@ -108,12 +108,14 @@ class WebViewModel(application: Application) : BaseViewModel(application) {
             execute {
                 val url = intent!!.getStringExtra("url")!!
                 val source = appDb.bookSourceDao.getBookSource(sourceOrigin)
-                html = AnalyzeUrl(
-                    url,
-                    headerMapF = headerMap,
-                    source = source,
-                    coroutineContext = coroutineContext
-                ).getStrResponseAwait(useWebView = false).body
+                if (html == null) {
+                    html = AnalyzeUrl(
+                        url,
+                        headerMapF = headerMap,
+                        source = source,
+                        coroutineContext = coroutineContext
+                    ).getStrResponseAwait(useWebView = false).body
+                }
                 SourceVerificationHelp.setResult(sourceOrigin, html ?: "")
             }.onSuccess {
                 success.invoke()

--- a/app/src/main/res/layout/item_chapter_list.xml
+++ b/app/src/main/res/layout/item_chapter_list.xml
@@ -17,7 +17,7 @@
         android:src="@drawable/ic_lock_outline"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:tint="@color/secondaryText" />
 
@@ -27,8 +27,8 @@
         android:layout_height="wrap_content"
         android:singleLine="true"
         app:layout_constraintBottom_toTopOf="@id/barrier"
-        app:layout_constraintLeft_toRightOf="@+id/iv_locked"
-        app:layout_constraintRight_toLeftOf="@+id/iv_checked"
+        app:layout_constraintStart_toEndOf="@+id/iv_locked"
+        app:layout_constraintEnd_toStartOf="@+id/iv_checked"
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.constraintlayout.widget.Barrier
@@ -37,31 +37,31 @@
         android:layout_height="wrap_content"
         app:barrierDirection="top"
         app:constraint_referenced_ids="tv_word_count,tv_tag" />
+        
+        <TextView
+        android:id="@+id/tv_tag"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:singleLine="true"
+        android:textSize="12sp"
+        android:visibility="gone"
+        android:paddingEnd="18dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/iv_locked"
+        app:layout_constraintTop_toBottomOf="@+id/barrier" />
 
-    <TextView
+        <TextView
         android:id="@+id/tv_word_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingEnd="18dp"
         android:singleLine="true"
         android:textSize="12sp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toRightOf="@+id/iv_locked"
+        app:layout_constraintStart_toEndOf="@id/tv_tag"
         app:layout_constraintTop_toBottomOf="@+id/barrier"
+        app:layout_goneMarginStart="0dp"
         tools:ignore="RtlSymmetry" />
-
-    <TextView
-        android:id="@+id/tv_tag"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:singleLine="true"
-        android:textSize="12sp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toRightOf="@id/tv_word_count"
-        app:layout_constraintRight_toLeftOf="@+id/iv_checked"
-        app:layout_constraintTop_toBottomOf="@+id/barrier" />
 
     <ImageView
         android:id="@+id/iv_checked"
@@ -72,7 +72,7 @@
         android:src="@drawable/ic_check"
         android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:tint="@color/secondaryText" />
 

--- a/app/src/main/res/layout/item_chapter_list.xml
+++ b/app/src/main/res/layout/item_chapter_list.xml
@@ -31,42 +31,44 @@
         app:layout_constraintEnd_toStartOf="@+id/iv_checked"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/barrier"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="top"
-        app:constraint_referenced_ids="tv_word_count,tv_tag" />
-
-        <TextView
+    <TextView
         android:id="@+id/tv_tag"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:singleLine="true"
         android:textSize="12sp"
         android:visibility="gone"
         android:paddingEnd="18dp"
+        android:ellipsize="end"
+        app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/iv_locked"
-        app:layout_constraintEnd_toStartOf="@id/tv_word_count"
         app:layout_constraintTop_toBottomOf="@+id/barrier"
-        app:layout_constraintWidth_default="wrap"
-        app:layout_constraintWidth_max="wrap" />
+        app:layout_constraintEnd_toStartOf="@id/tv_word_count"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintHorizontal_bias="0" />
 
-        <TextView
+    <TextView
         android:id="@+id/tv_word_count"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:singleLine="true"
         android:textSize="12sp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/tv_tag"
-        app:layout_constraintEnd_toStartOf="@id/iv_checked"
         app:layout_constraintTop_toBottomOf="@+id/barrier"
-        app:layout_constraintWidth_default="wrap"
-        app:layout_constraintWidth_max="wrap"
+        app:layout_constraintEnd_toStartOf="@id/iv_checked"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_goneMarginStart="0dp"
         tools:ignore="RtlSymmetry" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="top"
+        app:constraint_referenced_ids="tv_word_count,tv_tag" />
 
     <ImageView
         android:id="@+id/iv_checked"

--- a/app/src/main/res/layout/item_chapter_list.xml
+++ b/app/src/main/res/layout/item_chapter_list.xml
@@ -27,8 +27,8 @@
         android:layout_height="wrap_content"
         android:singleLine="true"
         app:layout_constraintBottom_toTopOf="@id/barrier"
-        app:layout_constraintStart_toEndOf="@+id/iv_locked"
-        app:layout_constraintEnd_toStartOf="@+id/iv_checked"
+        app:layout_constraintStart_toEndOf="@id/iv_locked"
+        app:layout_constraintEnd_toStartOf="@id/iv_checked"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
@@ -43,7 +43,7 @@
         app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/iv_locked"
-        app:layout_constraintTop_toBottomOf="@+id/barrier"
+        app:layout_constraintTop_toBottomOf="@id/barrier"
         app:layout_constraintEnd_toStartOf="@id/tv_word_count"
         app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintHorizontal_bias="0" />
@@ -57,7 +57,7 @@
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/tv_tag"
-        app:layout_constraintTop_toBottomOf="@+id/barrier"
+        app:layout_constraintTop_toBottomOf="@id/barrier"
         app:layout_constraintEnd_toStartOf="@id/iv_checked"
         app:layout_constraintHorizontal_bias="0"
         app:layout_goneMarginStart="0dp"

--- a/app/src/main/res/layout/item_chapter_list.xml
+++ b/app/src/main/res/layout/item_chapter_list.xml
@@ -37,10 +37,10 @@
         android:layout_height="wrap_content"
         app:barrierDirection="top"
         app:constraint_referenced_ids="tv_word_count,tv_tag" />
-        
+
         <TextView
         android:id="@+id/tv_tag"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:singleLine="true"
         android:textSize="12sp"
@@ -48,19 +48,24 @@
         android:paddingEnd="18dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/iv_locked"
-        app:layout_constraintTop_toBottomOf="@+id/barrier" />
+        app:layout_constraintEnd_toStartOf="@id/tv_word_count"
+        app:layout_constraintTop_toBottomOf="@+id/barrier"
+        app:layout_constraintWidth_default="wrap"
+        app:layout_constraintWidth_max="wrap" />
 
         <TextView
         android:id="@+id/tv_word_count"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:singleLine="true"
         android:textSize="12sp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/tv_tag"
+        app:layout_constraintEnd_toStartOf="@id/iv_checked"
         app:layout_constraintTop_toBottomOf="@+id/barrier"
-        app:layout_goneMarginStart="0dp"
+        app:layout_constraintWidth_default="wrap"
+        app:layout_constraintWidth_max="wrap"
         tools:ignore="RtlSymmetry" />
 
     <ImageView


### PR DESCRIPTION
一、给startBrowser和startBrowserAwait函数新增html字符串参数
url使用需模拟的域名，html参数传入html代码字符串即可解决跨域问题 #5208
```
java.startBrowser(url: String, title: String, html: String)
java.startBrowserAwait(url: String, title: String, refetchAfterSuccess: Boolean? = true, html: String): StrResponse
```
二、放开以前的限制，让卷名也能显示章节信息

三、让章节字数显示在章节信息右边
![Screenshot_2025-07-01-20-00-40-01_b46d61021eb8d6931849578836530a01](https://github.com/user-attachments/assets/553f65a7-8955-4a81-9c53-8faf467fcf7a)
章节信息超限后的显示效果

