### PR TITLE
优化img图片格式化规则

### DIFF
--- a/app/src/main/java/io/legado/app/utils/HtmlFormatter.kt
+++ b/app/src/main/java/io/legado/app/utils/HtmlFormatter.kt
@@ -14,7 +14,7 @@ object HtmlFormatter {
     private val notImgHtmlRegex = "</?(?!img)[a-zA-Z]+(?=[ >])[^<>]*>".toRegex()
     private val otherHtmlRegex = "</?[a-zA-Z]+(?=[ >])[^<>]*>".toRegex()
     private val formatImagePattern = Pattern.compile(
-        "<img[^>]*\\ssrc\\s*=\\s*['\"]([^'\"{>]*\\{(?:[^{}]|\\{[^}>]+\\})+\\})['\"][^>]*>|<img[^>]*\\s(?:data-src|src)\\s*=\\s*['\"]([^'\">]+)['\"][^>]*>|<img[^>]*\\sdata-[^=>]*=\\s*['\"]([^'\">]*)['\"][^>]*>",
+        "<img[^>]*\\ssrc\\s*=\\s*['\"]([^'\"{>]*\\{(?:[^{}]|\\{[^}>]+\\})+\\})['\"][^>]*>|<img[^>]*\\sdata-src\\s*=\\s*['\"]([^'\">]+)['\"][^>]*>|<img[^>]*\\ssrc\\s*=\\s*\"([^\">]+)\"[^>]*>|<img[^>]*\\s(?:data-[^=>]*|src)=\\s*['\"]([^'\">]*)['\"][^>]*>",
         Pattern.CASE_INSENSITIVE
     )
     private val indent1Regex = "\\s*\\n+\\s*".toRegex()
@@ -54,7 +54,7 @@ object HtmlFormatter {
                                 param = ',' + it.substring(urlMatcher.end())
                                 it.substring(0, urlMatcher.start())
                             } else it
-                        } ?: matcher.group(2) ?: matcher.group(3)!!
+                        } ?: matcher.group(2) ?: matcher.group(3) ?: matcher.group(4)!!
                     ) + param
                 }\">"
             )


### PR DESCRIPTION
增加一个捕获组。
按照带{括号链接、data-src、src、其它情况，的顺序进行匹配