### PR TITLE
Update MainActivity.kt with auto-explore startup feature

### DIFF
--- a/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
@@ -374,17 +374,19 @@ class MainActivity : VMBaseActivity<ActivityMainBinding, MainViewModel>(),
     }
 
     private fun upHomePage() {
-        when (AppConfig.defaultHomePage) {
-            "bookshelf" -> {}
-            "explore" -> if (AppConfig.showDiscovery) {
-                binding.viewPagerMain.setCurrentItem(realPositions.indexOf(idExplore), false)
-            }
+        // Always navigate to Explore page on startup if discovery is enabled
+        if (AppConfig.showDiscovery) {
+            binding.viewPagerMain.setCurrentItem(realPositions.indexOf(idExplore), false)
+        } else {
+            // Fallback to default behavior if discovery is disabled
+            when (AppConfig.defaultHomePage) {
+                "bookshelf" -> {}
+                "rss" -> if (AppConfig.showRSS) {
+                    binding.viewPagerMain.setCurrentItem(realPositions.indexOf(idRss), false)
+                }
 
-            "rss" -> if (AppConfig.showRSS) {
-                binding.viewPagerMain.setCurrentItem(realPositions.indexOf(idRss), false)
+                "my" -> binding.viewPagerMain.setCurrentItem(realPositions.indexOf(idMy), false)
             }
-
-            "my" -> binding.viewPagerMain.setCurrentItem(realPositions.indexOf(idMy), false)
         }
     }
 


### PR DESCRIPTION
标题:  feat: 应用启动时自动打开发现页

描述: 
- 修改 upHomePage() 方法强制在应用启动时跳转到发现页（Explore）
- 无论用户设置的默认首页配置如何，启动时都会自动打开发现页
- 保留原有的 when 分支逻辑以保证向后兼容性