### PR TITLE
feat: 漫畫模式支援關閉翻頁動畫

### DIFF
--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -166,6 +166,7 @@ object PreferKey {
     const val readAloudByMediaButton = "readAloudByMediaButton"
     const val showMangaUi = "showMangaUi"
     const val disableMangaScale = "disableMangaScale"
+    const val comicDisablePageAnim = "comicDisablePageAnim"
     const val paddingDisplayCutouts = "paddingDisplayCutouts"
     const val autoCheckNewBackup = "autoCheckNewBackup"
 

--- a/app/src/main/java/io/legado/app/help/config/AppConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfig.kt
@@ -623,6 +623,12 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
             appCtx.putPrefBoolean(PreferKey.disableMangaScale, value)
         }
 
+    var comicDisablePageAnim: Boolean
+        get() = appCtx.getPrefBoolean(PreferKey.comicDisablePageAnim, false)
+        set(value) {
+            appCtx.putPrefBoolean(PreferKey.comicDisablePageAnim, value)
+        }
+
     //漫画预加载数量
     var mangaPreDownloadNum
         get() = appCtx.getPrefInt(PreferKey.mangaPreDownloadNum, 10)

--- a/app/src/main/java/io/legado/app/ui/book/manga/ReadMangaActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/manga/ReadMangaActivity.kt
@@ -596,6 +596,18 @@ class ReadMangaActivity : VMBaseActivity<ActivityMangaBinding, ReadMangaViewMode
                 }
             }
 
+            R.id.menu_no_page_anim_comic -> {
+                item.isChecked = !item.isChecked
+                AppConfig.comicDisablePageAnim = item.isChecked
+                if (item.isChecked) {
+                    mPagerSnapHelper.attachToRecyclerView(null)
+                } else {
+                    if (AppConfig.enableMangaHorizontalScroll && !AppConfig.disableHorizontalPageSnap) {
+                        mPagerSnapHelper.attachToRecyclerView(binding.recyclerView)
+                    }
+                }
+            }
+
             R.id.menu_gray_manga -> {
                 item.isChecked = !item.isChecked
                 AppConfig.enableMangaGray = item.isChecked
@@ -689,6 +701,7 @@ class ReadMangaActivity : VMBaseActivity<ActivityMangaBinding, ReadMangaViewMode
             isVisible = AppConfig.enableMangaHorizontalScroll
             isChecked = AppConfig.disableHorizontalPageSnap
         }
+        menu.findItem(R.id.menu_no_page_anim_comic).isChecked = AppConfig.comicDisablePageAnim
         menu.findItem(R.id.menu_gray_manga).isChecked = AppConfig.enableMangaGray
     }
 
@@ -738,7 +751,11 @@ class ReadMangaActivity : VMBaseActivity<ActivityMangaBinding, ReadMangaViewMode
         }
         dx *= direction
         dy *= direction
-        binding.recyclerView.smoothScrollBy(dx, dy)
+        if (AppConfig.comicDisablePageAnim) {
+            binding.recyclerView.scrollBy(dx, dy)
+        } else {
+            binding.recyclerView.smoothScrollBy(dx, dy)
+        }
     }
 
     private fun showNumberPickerDialog(

--- a/app/src/main/res/menu/book_manga.xml
+++ b/app/src/main/res/menu/book_manga.xml
@@ -80,6 +80,13 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/menu_no_page_anim_comic"
+        android:checkable="true"
+        android:checked="false"
+        android:title="@string/disable_page_anim_comic"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/menu_manga_footer_config"
         android:title="@string/manga_footer_config"
         app:showAsAction="never" />

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -380,6 +380,7 @@
     <string name="page_anim_simulation">Simulación</string>
     <string name="page_anim_scroll">Desplazado</string>
     <string name="page_anim_none">Ninguno</string>
+    <string name="disable_page_anim_comic">Desactivar animación de volteo</string>
     <string name="up_change_source_last_chapter_t">Actualiza el último capítulo después del cambio de fuente en segundo plano</string>
     <string name="up_change_source_last_chapter_s">si está habilitado, la actualización comenzará 1 minuto después de que se abra la aplicación</string>
     <string name="behavior_main_t">Ocultar automáticamente la barra de herramientas</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -384,6 +384,7 @@
     <string name="page_anim_simulation">Simulation</string>
     <string name="page_anim_scroll">Scroll</string>
     <string name="page_anim_none">None</string>
+    <string name="disable_page_anim_comic">ページめくりアニメーションを無効にする</string>
     <string name="up_change_source_last_chapter_t">Update the latest chapter after changed origin in the background</string>
     <string name="up_change_source_last_chapter_s">if enabled,the update will start 1 minute later when the software is run</string>
     <string name="behavior_main_t">Auto hide ToolBar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -382,6 +382,7 @@
     <string name="page_anim_simulation">Simulação</string>
     <string name="page_anim_scroll">Deslizar</string>
     <string name="page_anim_none">Nenhum</string>
+    <string name="disable_page_anim_comic">Desativar animação de virada</string>
     <string name="up_change_source_last_chapter_t">Atualizar o último capítulo após a alteração de origem em segundo plano</string>
     <string name="up_change_source_last_chapter_s">se ativado, a atualização será iniciada 1 minuto depois o App for aberto</string>
     <string name="behavior_main_t">Auto esconder a barra de ferramentas</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -379,6 +379,7 @@
     <string name="page_anim_simulation">Mô phỏng</string>
     <string name="page_anim_scroll">Cuộn</string>
     <string name="page_anim_none">Không có</string>
+    <string name="disable_page_anim_comic">Tắt hiệu ứng lật trang</string>
     <string name="up_change_source_last_chapter_t">Cập nhật chương mới nhất sau khi đổi nguồn trong nền</string>
     <string name="up_change_source_last_chapter_s">Nếu được kích hoạt, cập nhật sẽ bắt đầu sau 1 phút khi phần mềm chạy</string>
     <string name="behavior_main_t">Tự động ẩn thanh công cụ</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -376,6 +376,7 @@
     <string name="page_anim_simulation">仿真</string>
     <string name="page_anim_scroll">滾動</string>
     <string name="page_anim_none">無動畫</string>
+    <string name="disable_page_anim_comic">禁用翻頁動畫</string>
     <string name="up_change_source_last_chapter_t">後台更新換源最新章節</string>
     <string name="up_change_source_last_chapter_s">開啟則會在軟件打開 1 分鐘後開始更新</string>
     <string name="behavior_main_t">書架 ToolBar 自動隱藏</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -378,6 +378,7 @@
     <string name="page_anim_simulation">模擬</string>
     <string name="page_anim_scroll">滾動</string>
     <string name="page_anim_none">無動畫</string>
+    <string name="disable_page_anim_comic">禁用翻頁動畫</string>
     <string name="up_change_source_last_chapter_t">後台更新換源最新章節</string>
     <string name="up_change_source_last_chapter_s">開啟則會在軟體打開1分鐘後開始更新</string>
     <string name="behavior_main_t">書架ToolBar自動隱藏</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -384,6 +384,7 @@
     <string name="page_anim_simulation">仿真</string>
     <string name="page_anim_scroll">滚动</string>
     <string name="page_anim_none">无动画</string>
+    <string name="disable_page_anim_comic">禁用翻页动画</string>
     <string name="up_change_source_last_chapter_t">后台更新换源最新章节</string>
     <string name="up_change_source_last_chapter_s">开启则会在软件打开 1 分钟后开始更新</string>
     <string name="behavior_main_t">书架工具栏自动隐藏</string>
@@ -1191,6 +1192,7 @@
     <string name="theme_config">主题配置</string>
     <string name="show_manga_ui">漫画浏览</string>
     <string name="disable_manga_scale">禁用漫画缩放</string>
+    <string name="comic_no_anim">关闭动画</string>
     <string name="disable_manga_click_scroll">禁用点击翻页</string>
     <string name="enable_auto_page_scroll">开启自动翻页</string>
     <string name="manga_auto_page_speed">翻页速度 %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,6 +208,7 @@
     <string name="click_turn_page">Tap screen to turn page</string>
     <string name="page_anim">Flip animation</string>
     <string name="book_page_anim">Flip animation (book)</string>
+    <string name="disable_page_anim_comic">Disable flip animation</string>
     <string name="keep_light">Keep screen awake</string>
     <string name="back">Back</string>
     <string name="menu">Menu</string>
@@ -1192,6 +1193,7 @@
     <string name="theme_config">主题配置</string>
     <string name="show_manga_ui">漫画浏览</string>
     <string name="disable_manga_scale">禁用漫画缩放</string>
+    <string name="comic_no_anim">Disable Anim</string>
     <string name="disable_manga_click_scroll">禁用点击翻页</string>
     <string name="enable_auto_page_scroll">开启自动翻页</string>
     <string name="manga_auto_page_speed">翻页速度 %s</string>


### PR DESCRIPTION
### 變更說明
在漫畫模式中新增「禁用翻頁動畫」功能。

### 調整細節
- 啟用後將關閉翻頁時的滑動特效，改為瞬間切換。
- **優化體驗**：特別針對電子書閱讀器（E-ink）優化，避免漫畫翻頁時產生的殘影與延遲。
- **適用場景**：漫畫模式下需要快速切換頁面且不希望有視覺干擾的使用者。